### PR TITLE
Refact : 리포트, 뉴스 도메인 리팩토링(Converter 분리, 예외처리, 문서화 등)

### DIFF
--- a/src/main/java/com/perfact/be/domain/news/config/SelectorConfig.java
+++ b/src/main/java/com/perfact/be/domain/news/config/SelectorConfig.java
@@ -47,30 +47,22 @@ public class SelectorConfig {
       ".article-time" // 기사 시간 클래스
   );
 
-  /**
-   * 제목 셀렉터 배열을 반환합니다.
-   */
+  // 제목 셀렉터 배열 밴환
   public String[] getTitleSelectors() {
     return TITLE_SELECTORS.toArray(new String[0]);
   }
 
-  /**
-   * 다른 뉴스 사이트 제목 셀렉터 배열을 반환합니다.
-   */
+  // 다른 뉴스 사이트 제목 셀렉터 배열 반환
   public String[] getOtherNewsTitleSelectors() {
     return OTHER_NEWS_TITLE_SELECTORS.toArray(new String[0]);
   }
 
-  /**
-   * 내용 셀렉터 배열을 반환합니다.
-   */
+  // 내용 셀렉터 배열 반환
   public String[] getContentSelectors() {
     return CONTENT_SELECTORS.toArray(new String[0]);
   }
 
-  /**
-   * 날짜 셀렉터 배열을 반환합니다.
-   */
+  // 날짜 셀렉터 배열 반환
   public String[] getDateSelectors() {
     return DATE_SELECTORS.toArray(new String[0]);
   }

--- a/src/main/java/com/perfact/be/domain/news/controller/NewsController.java
+++ b/src/main/java/com/perfact/be/domain/news/controller/NewsController.java
@@ -3,10 +3,14 @@ package com.perfact.be.domain.news.controller;
 import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import com.perfact.be.domain.news.service.NewsService;
 import com.perfact.be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "News", description = "뉴스 관련 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/news")
@@ -15,14 +19,18 @@ public class NewsController {
 
   private final NewsService newsService;
 
+  @Operation(summary = "뉴스 기사 내용 추출", description = "네이버 뉴스 URL을 입력받아 기사의 제목, 날짜, 내용을 추출합니다.")
   @GetMapping("/article-content")
-  public ApiResponse<NewsArticleResponse> getNewsArticleContent(@RequestParam String url) {
+  public ApiResponse<NewsArticleResponse> getNewsArticleContent(
+      @Parameter(description = "네이버 뉴스 URL", required = true, example = "https://news.naver.com/main/read.naver?mode=LSD&mid=shm&sid1=100&oid=001&aid=0012345678") @RequestParam String url) {
     NewsArticleResponse response = newsService.extractNaverNewsArticle(url);
     return ApiResponse.onSuccess(response);
   }
 
+  @Operation(summary = "네이버 뉴스 검색", description = "검색어를 입력받아 네이버 뉴스 검색 결과를 반환합니다.")
   @GetMapping("/search")
-  public ApiResponse<String> searchNaverNews(@RequestParam String query) {
+  public ApiResponse<String> searchNaverNews(
+      @Parameter(description = "검색할 키워드", required = true, example = "AI 기술") @RequestParam String query) {
     String searchResult = newsService.searchNaverNews(query);
     return ApiResponse.onSuccess(searchResult);
   }

--- a/src/main/java/com/perfact/be/domain/news/converter/NewsConverter.java
+++ b/src/main/java/com/perfact/be/domain/news/converter/NewsConverter.java
@@ -4,50 +4,16 @@ import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-/**
- * News 도메인의 데이터 변환을 담당하는 Converter
- */
 @Slf4j
 @Component
 public class NewsConverter {
 
-  /**
-   * 뉴스 데이터를 NewsArticleResponse로 변환
-   */
   public NewsArticleResponse toNewsArticleResponse(String title, String date, String content) {
     try {
       return new NewsArticleResponse(title, date, content);
     } catch (Exception e) {
+      log.error("NewsArticleResponse 변환 실패: {}", e.getMessage(), e);
       throw new RuntimeException("NewsArticleResponse 변환 실패", e);
     }
-  }
-
-  /**
-   * 뉴스 데이터를 JSON 형태로 변환
-   */
-  public String toJsonString(NewsArticleResponse newsData) {
-    try {
-      return String.format(
-          "{\"title\": \"%s\", \"date\": \"%s\", \"content\": \"%s\"}",
-          escapeJsonString(newsData.getTitle()),
-          escapeJsonString(newsData.getDate()),
-          escapeJsonString(newsData.getContent()));
-    } catch (Exception e) {
-      throw new RuntimeException("JSON 변환 실패", e);
-    }
-  }
-
-  /**
-   * JSON 문자열에서 특수문자 이스케이프 처리
-   */
-  private String escapeJsonString(String input) {
-    if (input == null) {
-      return "";
-    }
-    return input.replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t");
   }
 }

--- a/src/main/java/com/perfact/be/domain/news/dto/NewsArticleResponse.java
+++ b/src/main/java/com/perfact/be/domain/news/dto/NewsArticleResponse.java
@@ -1,5 +1,6 @@
 package com.perfact.be.domain.news.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,8 +8,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "뉴스 기사 응답 DTO")
 public class NewsArticleResponse {
+
+  @Schema(description = "뉴스 기사 제목", example = "AI 기술 발전으로 인한 산업 변화")
   private String title;
+
+  @Schema(description = "뉴스 발행일", example = "2025-08-06")
   private String date;
+
+  @Schema(description = "뉴스 기사 본문 내용", example = "최근 AI 기술의 급속한 발전으로 인해...")
   private String content;
 }

--- a/src/main/java/com/perfact/be/domain/news/exception/NewsExceptionHandler.java
+++ b/src/main/java/com/perfact/be/domain/news/exception/NewsExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.perfact.be.domain.news.exception;
 
 import com.perfact.be.domain.news.exception.status.NewsErrorStatus;
-import com.perfact.be.global.exception.GeneralException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -9,52 +8,40 @@ import org.springframework.stereotype.Component;
 @Component
 public class NewsExceptionHandler {
 
-  /**
-   * 뉴스 파싱 실패 시 예외를 처리합니다.
-   */
+  // 뉴스 파싱 실패 예외 처리
   public void handleParsingFailure(String url, String operation, Exception e) {
     log.error("Failed to {} for URL: {}", operation, url, e);
-    throw new GeneralException(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
+    throw new NewsHandler(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
   }
 
-  /**
-   * 뉴스 내용을 찾을 수 없을 때 예외를 처리합니다.
-   */
+  // 뉴스 내용 찾을 수 없을 때 예외 처리
   public void handleContentNotFound(String url, String operation) {
     log.warn("Content not found during {} for URL: {}", operation, url);
-    throw new GeneralException(NewsErrorStatus.NEWS_CONTENT_NOT_FOUND);
+    throw new NewsHandler(NewsErrorStatus.NEWS_CONTENT_NOT_FOUND);
   }
 
-  /**
-   * 뉴스 제목 추출 실패 시 예외를 처리합니다.
-   */
+  // 뉴스 제목 추출 실패 예외 처리
   public void handleTitleExtractionFailure(String url, String operation, Exception e) {
     log.error("Failed to extract title during {} for URL: {}", operation, url, e);
-    throw new GeneralException(NewsErrorStatus.NEWS_TITLE_EXTRACTION_FAILED);
+    throw new NewsHandler(NewsErrorStatus.NEWS_TITLE_EXTRACTION_FAILED);
   }
 
-  /**
-   * 네이버 API 호출 실패 시 예외를 처리합니다.
-   */
+  // 네이버 API 호출 실패 예외 처리
   public void handleNaverApiFailure(String query, Exception e) {
     log.error("Failed to call Naver API for query: {}", query, e);
-    throw new GeneralException(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
+    throw new NewsHandler(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
   }
 
-  /**
-   * 안전한 텍스트 추출을 수행합니다. 실패 시 null을 반환합니다.
-   */
+  // 안전한 텍스트 추출 수행 실패 시 null 반환
   public String safeExtractText(String url, String operation, TextExtractor extractor) {
     try {
       return extractor.extract();
     } catch (Exception e) {
+      log.warn("Text extraction failed during {} for URL: {}", operation, url, e);
       return null;
     }
   }
 
-  /**
-   * 텍스트 추출을 위한 함수형 인터페이스
-   */
   @FunctionalInterface
   public interface TextExtractor {
     String extract() throws Exception;

--- a/src/main/java/com/perfact/be/domain/news/exception/NewsHandler.java
+++ b/src/main/java/com/perfact/be/domain/news/exception/NewsHandler.java
@@ -1,0 +1,10 @@
+package com.perfact.be.domain.news.exception;
+
+import com.perfact.be.global.apiPayload.code.BaseErrorCode;
+import com.perfact.be.global.exception.GeneralException;
+
+public class NewsHandler extends GeneralException {
+  public NewsHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/perfact/be/domain/news/service/HtmlParserServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/news/service/HtmlParserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.perfact.be.domain.news.service;
 
+import com.perfact.be.domain.news.exception.NewsHandler;
 import com.perfact.be.domain.news.exception.status.NewsErrorStatus;
-import com.perfact.be.global.exception.GeneralException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -25,7 +25,7 @@ public class HtmlParserServiceImpl implements HtmlParserService {
       return doc;
 
     } catch (IOException e) {
-      throw new GeneralException(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
+      throw new NewsHandler(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
     }
   }
 
@@ -42,7 +42,7 @@ public class HtmlParserServiceImpl implements HtmlParserService {
       return element;
 
     } catch (Exception e) {
-      throw new GeneralException(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
+      throw new NewsHandler(NewsErrorStatus.NEWS_ARTICLE_PARSING_FAILED);
     }
   }
 

--- a/src/main/java/com/perfact/be/domain/news/service/NaverApiServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/news/service/NaverApiServiceImpl.java
@@ -1,7 +1,7 @@
 package com.perfact.be.domain.news.service;
 
+import com.perfact.be.domain.news.exception.NewsHandler;
 import com.perfact.be.domain.news.exception.status.NewsErrorStatus;
-import com.perfact.be.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -46,11 +46,11 @@ public class NaverApiServiceImpl implements NaverApiService {
       if (response.getStatusCode() == HttpStatus.OK) {
         return response.getBody();
       } else {
-        throw new GeneralException(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
+        throw new NewsHandler(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
       }
 
     } catch (Exception e) {
-      throw new GeneralException(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
+      throw new NewsHandler(NewsErrorStatus.NEWS_NAVER_API_CALL_FAILED);
     }
   }
 

--- a/src/main/java/com/perfact/be/domain/news/service/NewsExtractorServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/news/service/NewsExtractorServiceImpl.java
@@ -1,7 +1,8 @@
 package com.perfact.be.domain.news.service;
 
+import com.perfact.be.domain.news.config.SelectorConfig;
+import com.perfact.be.domain.news.exception.NewsHandler;
 import com.perfact.be.domain.news.exception.status.NewsErrorStatus;
-import com.perfact.be.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Service;
 public class NewsExtractorServiceImpl implements NewsExtractorService {
 
   private final HtmlParserService htmlParserService;
-  private final com.perfact.be.domain.news.config.SelectorConfig selectorConfig;
+  private final SelectorConfig selectorConfig;
 
   // 뉴스 기사 내용 추출
   @Override
@@ -35,7 +36,7 @@ public class NewsExtractorServiceImpl implements NewsExtractorService {
       return content.toString();
 
     } catch (Exception e) {
-      throw new GeneralException(NewsErrorStatus.NEWS_CONTENT_NOT_FOUND);
+      throw new NewsHandler(NewsErrorStatus.NEWS_CONTENT_NOT_FOUND);
     }
   }
 

--- a/src/main/java/com/perfact/be/domain/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/news/service/NewsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.perfact.be.domain.news.service;
 
+import com.perfact.be.domain.news.config.SelectorConfig;
 import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import com.perfact.be.domain.news.exception.NewsExceptionHandler;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ public class NewsServiceImpl implements NewsService {
   private final NewsExtractorService newsExtractorService;
   private final DateExtractorService dateExtractorService;
   private final NewsExceptionHandler exceptionHandler;
-  private final com.perfact.be.domain.news.config.SelectorConfig selectorConfig;
+  private final SelectorConfig selectorConfig;
 
   @Override
   public org.jsoup.nodes.Document getHtmlFromUrl(String url) {

--- a/src/main/java/com/perfact/be/domain/news/util/JsonUtil.java
+++ b/src/main/java/com/perfact/be/domain/news/util/JsonUtil.java
@@ -1,0 +1,37 @@
+package com.perfact.be.domain.news.util;
+
+import com.perfact.be.domain.news.dto.NewsArticleResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+// JSON 관련 유틸리티 클래스
+@Slf4j
+@Component
+public class JsonUtil {
+
+  // NewsArticleResponse를 JSON 문자열로 변환
+  public String toJsonString(NewsArticleResponse newsData) {
+    try {
+      return String.format(
+          "{\"title\": \"%s\", \"date\": \"%s\", \"content\": \"%s\"}",
+          escapeJsonString(newsData.getTitle()),
+          escapeJsonString(newsData.getDate()),
+          escapeJsonString(newsData.getContent()));
+    } catch (Exception e) {
+      log.error("JSON 변환 실패: {}", e.getMessage(), e);
+      throw new RuntimeException("JSON 변환 실패", e);
+    }
+  }
+
+  // JSON 문자열에서 특수 문자를 이스케이프 처리
+  private String escapeJsonString(String input) {
+    if (input == null) {
+      return "";
+    }
+    return input.replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t");
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/controller/ReportController.java
+++ b/src/main/java/com/perfact/be/domain/report/controller/ReportController.java
@@ -1,16 +1,26 @@
 package com.perfact.be.domain.report.controller;
 
 import com.perfact.be.domain.report.dto.AnalyzeNewsRequestDTO;
+import com.perfact.be.domain.report.dto.ReportResponseDto;
 import com.perfact.be.domain.report.entity.Report;
+import com.perfact.be.domain.report.entity.ReportBadge;
+import com.perfact.be.domain.report.entity.TrueScore;
+import com.perfact.be.domain.report.repository.ReportBadgeRepository;
+import com.perfact.be.domain.report.repository.TrueScoreRepository;
 import com.perfact.be.domain.report.service.ReportService;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.global.apiPayload.ApiResponse;
 import com.perfact.be.global.resolver.CurrentUser;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Tag(name = "Report", description = "리포트 관련 API")
 @Slf4j
 @RestController
 @RequestMapping("/api/report")
@@ -18,20 +28,29 @@ import org.springframework.web.bind.annotation.*;
 public class ReportController {
 
   private final ReportService reportService;
+  private final TrueScoreRepository trueScoreRepository;
+  private final ReportBadgeRepository reportBadgeRepository;
 
+  @Operation(summary = "뉴스 기사 AI 분석 및 리포트 생성", description = "뉴스 URL을 입력받아 Clova API를 통해 AI 분석을 수행하고 리포트를 생성하여 저장합니다.")
   @PostMapping("")
-  public ApiResponse<Object> analyzeNewsWithClova(
-      @RequestBody AnalyzeNewsRequestDTO request) {
-    Object analysisResult = reportService.analyzeNewsWithClova(request.getUrl());
-    return ApiResponse.onSuccess(analysisResult);
-  }
+  public ApiResponse<ReportResponseDto> analyzeNewsAndCreateReport(
+      @Parameter(description = "분석할 뉴스 URL", required = true, example = "https://news.naver.com/main/read.naver?mode=LSD&mid=shm&sid1=100&oid=001&aid=0012345678") @RequestBody AnalyzeNewsRequestDTO request,
+      @CurrentUser @Parameter(hidden = true) User loginUser) {
+    log.info("뉴스 분석 요청 - URL: {}", request.getUrl());
 
-  @PostMapping("/create")
-  public ApiResponse<Report> createReport(
-      @RequestBody AnalyzeNewsRequestDTO request,
-      @CurrentUser @Parameter(hidden=true) User loginUser) {
+    // 1. Clova API를 통한 뉴스 분석
     Object analysisResult = reportService.analyzeNewsWithClova(request.getUrl());
-    Report report = reportService.createReport(loginUser, request.getUrl(), analysisResult);
-    return ApiResponse.onSuccess(report);
+
+    // 2. 분석 결과를 바탕으로 리포트 생성 및 저장
+    Report report = reportService.createReportFromAnalysis(analysisResult, request.getUrl(), loginUser);
+
+    // 3. 관련 데이터 조회
+    TrueScore trueScore = trueScoreRepository.findByReportId(report.getReportId()).orElse(null);
+    List<ReportBadge> reportBadges = reportBadgeRepository.findByReportId(report.getReportId());
+
+    // 4. DTO로 변환하여 반환
+    ReportResponseDto responseDto = ReportResponseDto.from(report, trueScore, reportBadges);
+
+    return ApiResponse.onSuccess(responseDto);
   }
 }

--- a/src/main/java/com/perfact/be/domain/report/converter/ClovaAnalysisConverter.java
+++ b/src/main/java/com/perfact/be/domain/report/converter/ClovaAnalysisConverter.java
@@ -1,0 +1,246 @@
+package com.perfact.be.domain.report.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.perfact.be.domain.news.dto.NewsArticleResponse;
+import com.perfact.be.domain.report.entity.Badge;
+import com.perfact.be.domain.report.entity.Report;
+import com.perfact.be.domain.report.entity.ReportBadge;
+import com.perfact.be.domain.report.entity.TrueScore;
+import com.perfact.be.domain.report.exception.ReportHandler;
+import com.perfact.be.domain.report.exception.status.ReportErrorStatus;
+import com.perfact.be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClovaAnalysisConverter {
+
+  private final ObjectMapper objectMapper;
+
+  public Report convertToReport(String analysisResult, NewsArticleResponse newsData, User user, String url) {
+    try {
+      JsonNode analysis = objectMapper.readTree(analysisResult);
+
+      // 원본 분석 결과 로깅
+      log.debug("=== 클로바 분석 결과 원본 ===");
+      log.debug("analysisResult: {}", analysisResult);
+      log.debug("analysis JSON: {}", analysis.toString());
+
+      // 필수 필드들이 존재하는지 확인하고 안전하게 추출
+      String category = getStringValue(analysis, "field", "분류 없음");
+      String source = getStringValue(analysis, "source", "출처 없음");
+      String chatbotContext = getStringValue(analysis, "chatbot_context", "챗봇 컨텍스트 없음");
+
+      // 요약 정보 추출 (summary 필드가 있으면 사용, 없으면 기본값)
+      log.debug("=== summary 필드 처리 ===");
+      JsonNode summaryNode = analysis.get("summary");
+      log.debug("summaryNode: {}", summaryNode);
+      log.debug("summaryNode.isNull(): {}", summaryNode != null ? summaryNode.isNull() : "null");
+      log.debug("summaryNode.isArray(): {}", summaryNode != null ? summaryNode.isArray() : "null");
+      log.debug("summaryNode.isTextual(): {}", summaryNode != null ? summaryNode.isTextual() : "null");
+
+      String summary = "요약 정보 없음";
+      if (summaryNode != null && !summaryNode.isNull()) {
+        if (summaryNode.isArray()) {
+          // 배열인 경우 문자열로 결합
+          StringBuilder summaryBuilder = new StringBuilder();
+          for (JsonNode item : summaryNode) {
+            if (item.isTextual()) {
+              summaryBuilder.append(item.asText()).append(" ");
+            }
+          }
+          summary = summaryBuilder.toString().trim();
+          log.debug("summary (배열에서 결합): {}", summary);
+        } else if (summaryNode.isTextual()) {
+          // 문자열인 경우 그대로 사용
+          summary = summaryNode.asText();
+          log.debug("summary (문자열): {}", summary);
+        }
+      }
+
+      log.debug("최종 summary: {}", summary);
+
+      return Report.builder()
+          .user(user)
+          .title(newsData.getTitle())
+          .category(category)
+          .url(url)
+          .publisher(source)
+          .publicationDate(parsePublicationDate(newsData.getDate()))
+          .summary(summary)
+          .chatbotContext(chatbotContext)
+          .build();
+    } catch (Exception e) {
+      log.error("분석 결과를 Report로 변환 실패: {}", e.getMessage(), e);
+      log.error("분석 결과 원본: {}", analysisResult);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CONVERSION_FAILED);
+    }
+  }
+
+  public TrueScore convertToTrueScore(String analysisResult) {
+    try {
+      JsonNode analysis = objectMapper.readTree(analysisResult);
+      JsonNode reliabilityAnalysis = analysis.get("reliability_analysis");
+
+      int sourceReliability = 0;
+      int factualBasis = 0;
+      int adExaggeration = 0;
+      int bias = 0;
+      int articleStructure = 0;
+
+      if (reliabilityAnalysis != null && reliabilityAnalysis.isArray()) {
+        for (JsonNode item : reliabilityAnalysis) {
+          String categoryName = getStringValue(item, "category_name", "");
+          int score = getIntValue(item, "score", 0);
+
+          switch (categoryName) {
+            case "출처 신뢰성":
+              sourceReliability = score;
+              break;
+            case "사실 근거":
+              factualBasis = score;
+              break;
+            case "광고/과장 표현":
+              adExaggeration = score;
+              break;
+            case "편향성":
+              bias = score;
+              break;
+            case "기사 형식":
+              articleStructure = score;
+              break;
+          }
+        }
+      }
+
+      int overallScore = getIntValue(analysis, "total_score", 0);
+
+      return TrueScore.builder()
+          .sourceReliability(sourceReliability)
+          .factualBasis(factualBasis)
+          .adExaggeration(adExaggeration)
+          .bias(bias)
+          .articleStructure(articleStructure)
+          .overallScore(overallScore)
+          .build();
+    } catch (Exception e) {
+      log.error("분석 결과를 TrueScore로 변환 실패: {}", e.getMessage(), e);
+      log.error("분석 결과 원본: {}", analysisResult);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CONVERSION_FAILED);
+    }
+  }
+
+  public List<ReportBadge> convertToReportBadges(String analysisResult) {
+    try {
+      JsonNode analysis = objectMapper.readTree(analysisResult);
+      List<ReportBadge> reportBadges = new ArrayList<>();
+
+      JsonNode aiBadgesNode = analysis.get("ai_badges");
+      if (aiBadgesNode != null && aiBadgesNode.isArray()) {
+        for (JsonNode badgeNode : aiBadgesNode) {
+          String badgeName = badgeNode.asText();
+          Badge.BadgeName badgeEnum = convertBadgeName(badgeName);
+
+          Badge badge = Badge.builder()
+              .badgeName(badgeEnum)
+              .build();
+
+          ReportBadge reportBadge = ReportBadge.builder()
+              .badge(badge)
+              .build();
+
+          reportBadges.add(reportBadge);
+        }
+      }
+
+      return reportBadges;
+    } catch (Exception e) {
+      log.error("분석 결과를 ReportBadge로 변환 실패: {}", e.getMessage(), e);
+      log.error("분석 결과 원본: {}", analysisResult);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CONVERSION_FAILED);
+    }
+  }
+
+  private Badge.BadgeName convertBadgeName(String badgeName) {
+    switch (badgeName) {
+      case "공신력 있는 출처":
+        return Badge.BadgeName.RELIABLE_SOURCE;
+      case "균형 잡힌 기사":
+        return Badge.BadgeName.BALANCED_ARTICLE;
+      case "주의 환기 우수":
+        return Badge.BadgeName.EXCELLENT_WARNING;
+      case "부분적인 신뢰 가능":
+        return Badge.BadgeName.PARTIALLY_TRUSTWORTHY;
+      case "전문가 인용 없음":
+        return Badge.BadgeName.NO_EXPERT_CITATION;
+      case "광고성 기사":
+        return Badge.BadgeName.ADVERTORIAL_ARTICLE;
+      case "사실 검증 불가":
+        return Badge.BadgeName.FACT_VERIFICATION_IMPOSSIBLE;
+      case "신뢰 불가":
+        return Badge.BadgeName.UNTRUSTWORTHY;
+      case "광고 목적":
+        return Badge.BadgeName.ADVERTISING_PURPOSE;
+      case "과장 표현 다수":
+        return Badge.BadgeName.MANY_EXAGGERATED_EXPRESSIONS;
+      default:
+        return Badge.BadgeName.RELIABLE_SOURCE; // 기본값
+    }
+  }
+
+  private LocalDate parsePublicationDate(String dateStr) {
+    try {
+      if (dateStr == null || dateStr.equals("날짜 정보 없음")) {
+        return LocalDate.now();
+      }
+
+      // 다양한 날짜 형식 처리
+      String cleanDate = dateStr.trim();
+
+      // "2025.08.05" 형식 처리
+      if (cleanDate.matches("\\d{4}\\.\\d{2}\\.\\d{2}")) {
+        String[] parts = cleanDate.split("\\.");
+        int year = Integer.parseInt(parts[0]);
+        int month = Integer.parseInt(parts[1]);
+        int day = Integer.parseInt(parts[2]);
+        return LocalDate.of(year, month, day);
+      }
+
+      // 기존 로직 (ISO 형식)
+      if (cleanDate.length() >= 10) {
+        return LocalDate.parse(cleanDate.substring(0, 10));
+      }
+
+      return LocalDate.now();
+    } catch (Exception e) {
+      log.warn("날짜 파싱 실패 - dateStr: {}, 에러: {}", dateStr, e.getMessage());
+      return LocalDate.now();
+    }
+  }
+
+  // 안전한 문자열 값 추출을 위한 헬퍼 메서드
+  private String getStringValue(JsonNode node, String fieldName, String defaultValue) {
+    JsonNode fieldNode = node.get(fieldName);
+    if (fieldNode != null && !fieldNode.isNull()) {
+      return fieldNode.asText();
+    }
+    return defaultValue;
+  }
+
+  // 안전한 정수 값 추출을 위한 헬퍼 메서드
+  private int getIntValue(JsonNode node, String fieldName, int defaultValue) {
+    JsonNode fieldNode = node.get(fieldName);
+    if (fieldNode != null && !fieldNode.isNull()) {
+      return fieldNode.asInt();
+    }
+    return defaultValue;
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/converter/ReportConverter.java
+++ b/src/main/java/com/perfact/be/domain/report/converter/ReportConverter.java
@@ -3,22 +3,33 @@ package com.perfact.be.domain.report.converter;
 import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import com.perfact.be.domain.report.dto.ClovaResponseDTO;
 import com.perfact.be.domain.report.entity.Report;
+import com.perfact.be.domain.report.exception.ReportHandler;
+import com.perfact.be.domain.report.exception.status.ReportErrorStatus;
+import com.perfact.be.domain.report.util.ClovaResponseParser;
+import com.perfact.be.domain.report.util.DateParser;
+import com.perfact.be.domain.report.util.UrlParser;
 import com.perfact.be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ReportConverter {
+
+  private final ClovaResponseParser clovaResponseParser;
+  private final UrlParser urlParser;
+  private final DateParser dateParser;
 
   // Clova API 응답과 뉴스 데이터를 Report 엔티티로 변환
   public Report toReport(ClovaResponseDTO clovaResponse, NewsArticleResponse newsData, User user, String url) {
     try {
-      String category = extractCategoryFromAnalysis(clovaResponse);
-      String summary = extractSummaryFromAnalysis(clovaResponse);
-      String publisher = extractPublisherFromUrl(url);
+      String content = clovaResponse.getResult().getMessage().getContent();
+
+      String category = clovaResponseParser.extractCategory(content);
+      String summary = clovaResponseParser.extractSummary(content);
+      String publisher = urlParser.extractPublisher(url);
 
       return Report.builder()
           .user(user)
@@ -26,67 +37,12 @@ public class ReportConverter {
           .category(category)
           .url(url)
           .publisher(publisher)
-          .publicationDate(parsePublicationDate(newsData.getDate()))
+          .publicationDate(dateParser.parsePublicationDate(newsData.getDate()))
           .summary(summary)
           .build();
     } catch (Exception e) {
-      throw new RuntimeException("리포트 변환 실패", e);
-    }
-  }
-
-  // 분석 결과에서 카테고리 추출
-  private String extractCategoryFromAnalysis(ClovaResponseDTO clovaResponse) {
-    try {
-      String content = clovaResponse.getResult().getMessage().getContent();
-      if (content.contains("\"field\"")) {
-        int start = content.indexOf("\"field\"") + 8;
-        int end = content.indexOf("\"", start);
-        if (start > 7 && end > start) {
-          return content.substring(start, end);
-        }
-      }
-      return "기타";
-    } catch (Exception e) {
-      return "기타";
-    }
-  }
-
-  // 분석 결과에서 요약 추출
-  private String extractSummaryFromAnalysis(ClovaResponseDTO clovaResponse) {
-    try {
-      String content = clovaResponse.getResult().getMessage().getContent();
-      if (content.contains("\"summary\"")) {
-        int start = content.indexOf("\"summary\"") + 10;
-        int end = content.indexOf("]", start);
-        if (start > 9 && end > start) {
-          return content.substring(start, end).replaceAll("\"", "").replaceAll(",", "\n");
-        }
-      }
-      return "";
-    } catch (Exception e) {
-      return "";
-    }
-  }
-
-  // URL에서 출판사 추출
-  private String extractPublisherFromUrl(String url) {
-    try {
-      String domain = url.replaceAll("https?://", "").replaceAll("www\\.", "");
-      return domain.split("/")[0];
-    } catch (Exception e) {
-      return "unknown";
-    }
-  }
-
-  // 날짜 문자열을 LocalDate로 변환
-  private LocalDate parsePublicationDate(String dateStr) {
-    try {
-      if (dateStr == null || dateStr.equals("날짜 정보 없음")) {
-        return LocalDate.now();
-      }
-      return LocalDate.parse(dateStr.substring(0, 10));
-    } catch (Exception e) {
-      return LocalDate.now();
+      log.error("리포트 변환 실패: {}", e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CONVERSION_FAILED);
     }
   }
 }

--- a/src/main/java/com/perfact/be/domain/report/dto/ClovaResponseDTO.java
+++ b/src/main/java/com/perfact/be/domain/report/dto/ClovaResponseDTO.java
@@ -1,5 +1,6 @@
 package com.perfact.be.domain.report.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,16 +12,25 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Clova API 응답 DTO")
 public class ClovaResponseDTO {
+
+  @Schema(description = "API 응답 상태 정보")
   private Status status;
+
+  @Schema(description = "API 응답 결과")
   private Result result;
 
   @Getter
   @Setter
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = "API 응답 상태")
   public static class Status {
+    @Schema(description = "응답 코드", example = "200")
     private String code;
+
+    @Schema(description = "응답 메시지", example = "OK")
     private String message;
   }
 
@@ -28,12 +38,24 @@ public class ClovaResponseDTO {
   @Setter
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = "API 응답 결과")
   public static class Result {
+    @Schema(description = "AI 응답 메시지")
     private Message message;
+
+    @Schema(description = "완료 이유", example = "stop")
     private String finishReason;
+
+    @Schema(description = "생성 시간", example = "1642234567")
     private long created;
+
+    @Schema(description = "시드 값", example = "12345")
     private long seed;
+
+    @Schema(description = "토큰 사용량")
     private Usage usage;
+
+    @Schema(description = "AI 필터 정보")
     private List<AiFilter> aiFilter;
   }
 
@@ -41,8 +63,12 @@ public class ClovaResponseDTO {
   @Setter
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = "AI 응답 메시지")
   public static class Message {
+    @Schema(description = "메시지 역할", example = "assistant")
     private String role;
+
+    @Schema(description = "메시지 내용", example = "{\"field\": \"정치\", \"summary\": \"기사 요약...\"}")
     private String content;
   }
 
@@ -50,9 +76,15 @@ public class ClovaResponseDTO {
   @Setter
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = "토큰 사용량")
   public static class Usage {
+    @Schema(description = "프롬프트 토큰 수", example = "100")
     private int promptTokens;
+
+    @Schema(description = "완료 토큰 수", example = "200")
     private int completionTokens;
+
+    @Schema(description = "총 토큰 수", example = "300")
     private int totalTokens;
   }
 
@@ -60,10 +92,18 @@ public class ClovaResponseDTO {
   @Setter
   @NoArgsConstructor
   @AllArgsConstructor
+  @Schema(description = "AI 필터 정보")
   public static class AiFilter {
+    @Schema(description = "필터 그룹명", example = "content_filter")
     private String groupName;
+
+    @Schema(description = "필터명", example = "hate")
     private String name;
+
+    @Schema(description = "필터 점수", example = "0.1")
     private String score;
+
+    @Schema(description = "필터 결과", example = "pass")
     private String result;
   }
 }

--- a/src/main/java/com/perfact/be/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/com/perfact/be/domain/report/dto/ReportResponseDto.java
@@ -1,0 +1,139 @@
+package com.perfact.be.domain.report.dto;
+
+import com.perfact.be.domain.report.entity.Report;
+import com.perfact.be.domain.report.entity.ReportBadge;
+import com.perfact.be.domain.report.entity.TrueScore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "뉴스 분석 리포트 응답 DTO")
+public class ReportResponseDto {
+
+  @Schema(description = "리포트 ID", example = "1")
+  private Long reportId;
+
+  @Schema(description = "뉴스 제목", example = "뉴스 제목입니다")
+  private String title;
+
+  @Schema(description = "뉴스 카테고리", example = "사회")
+  private String category;
+
+  @Schema(description = "뉴스 URL", example = "https://news.naver.com/...")
+  private String url;
+
+  @Schema(description = "출판사", example = "네이버뉴스")
+  private String publisher;
+
+  @Schema(description = "발행일", example = "2025-08-06")
+  private String publicationDate;
+
+  @Schema(description = "요약", example = "뉴스 요약 내용입니다")
+  private String summary;
+
+  @Schema(description = "챗봇 컨텍스트", example = "AI 분석 결과입니다")
+  private String chatbotContext;
+
+  @Schema(description = "생성일시")
+  private LocalDateTime createdAt;
+
+  @Schema(description = "수정일시")
+  private LocalDateTime updatedAt;
+
+  @Schema(description = "신뢰도 점수 정보")
+  private TrueScoreDto trueScore;
+
+  @Schema(description = "AI 판단 배지 목록")
+  private List<ReportBadgeDto> reportBadges;
+
+  public static ReportResponseDto from(Report report, TrueScore trueScore, List<ReportBadge> reportBadges) {
+    return ReportResponseDto.builder()
+        .reportId(report.getReportId())
+        .title(report.getTitle())
+        .category(report.getCategory())
+        .url(report.getUrl())
+        .publisher(report.getPublisher())
+        .publicationDate(report.getPublicationDate().toString())
+        .summary(report.getSummary())
+        .chatbotContext(report.getChatbotContext())
+        .createdAt(report.getCreatedAt())
+        .updatedAt(report.getUpdatedAt())
+        .trueScore(trueScore != null ? TrueScoreDto.from(trueScore) : null)
+        .reportBadges(reportBadges != null ? reportBadges.stream()
+            .map(ReportBadgeDto::from)
+            .collect(Collectors.toList()) : null)
+        .build();
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "신뢰도 점수 DTO")
+  public static class TrueScoreDto {
+
+    @Schema(description = "출처 신뢰성 점수", example = "80")
+    private Integer sourceReliability;
+
+    @Schema(description = "사실 근거 점수", example = "85")
+    private Integer factualBasis;
+
+    @Schema(description = "광고/과장 표현 점수", example = "90")
+    private Integer adExaggeration;
+
+    @Schema(description = "편향성 점수", example = "75")
+    private Integer bias;
+
+    @Schema(description = "기사 형식 점수", example = "88")
+    private Integer articleStructure;
+
+    @Schema(description = "전체 신뢰도 점수", example = "84")
+    private Integer overallScore;
+
+    public static TrueScoreDto from(TrueScore trueScore) {
+      return TrueScoreDto.builder()
+          .sourceReliability(trueScore.getSourceReliability())
+          .factualBasis(trueScore.getFactualBasis())
+          .adExaggeration(trueScore.getAdExaggeration())
+          .bias(trueScore.getBias())
+          .articleStructure(trueScore.getArticleStructure())
+          .overallScore(trueScore.getOverallScore())
+          .build();
+    }
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "리포트 배지 DTO")
+  public static class ReportBadgeDto {
+
+    @Schema(description = "배지 ID", example = "1")
+    private Long badgeId;
+
+    @Schema(description = "배지 이름", example = "신뢰 가능")
+    private String badgeName;
+
+    @Schema(description = "배지 설명", example = "이 기사는 신뢰할 수 있습니다")
+    private String badgeDescription;
+
+    public static ReportBadgeDto from(ReportBadge reportBadge) {
+      return ReportBadgeDto.builder()
+          .badgeId(reportBadge.getBadge().getBadgeId())
+          .badgeName(reportBadge.getBadge().getBadgeName().name())
+          .badgeDescription(reportBadge.getBadge().getBadgeName().getDisplayName())
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/entity/Badge.java
+++ b/src/main/java/com/perfact/be/domain/report/entity/Badge.java
@@ -1,0 +1,49 @@
+package com.perfact.be.domain.report.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "badges")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Badge {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "badge_id")
+  private Long badgeId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "badge_name")
+  private BadgeName badgeName;
+
+  public enum BadgeName {
+    RELIABLE_SOURCE("공신력 있는 출처"),
+    BALANCED_ARTICLE("균형 잡힌 기사"),
+    EXCELLENT_WARNING("주의 환기 우수"),
+    PARTIALLY_TRUSTWORTHY("부분적인 신뢰 가능"),
+    NO_EXPERT_CITATION("전문가 인용 없음"),
+    ADVERTORIAL_ARTICLE("광고성 기사"),
+    FACT_VERIFICATION_IMPOSSIBLE("사실 검증 불가"),
+    UNTRUSTWORTHY("신뢰 불가"),
+    ADVERTISING_PURPOSE("광고 목적"),
+    MANY_EXAGGERATED_EXPRESSIONS("과장 표현 다수");
+
+    private final String displayName;
+
+    BadgeName(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/entity/Report.java
+++ b/src/main/java/com/perfact/be/domain/report/entity/Report.java
@@ -1,18 +1,24 @@
 package com.perfact.be.domain.report.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "reports")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 
@@ -21,6 +27,7 @@ public class Report extends BaseEntity {
   @Column(name = "report_id")
   private Long reportId;
 
+  @JsonIgnore
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;
@@ -43,15 +50,10 @@ public class Report extends BaseEntity {
   @Column(name = "summary", columnDefinition = "TEXT")
   private String summary;
 
-  @Builder
-  public Report(User user, String title, String category, String url,
-      String publisher, LocalDate publicationDate, String summary) {
+  @Column(name = "chatbot_context", columnDefinition = "TEXT")
+  private String chatbotContext;
+
+  public void setUser(User user) {
     this.user = user;
-    this.title = title;
-    this.category = category;
-    this.url = url;
-    this.publisher = publisher;
-    this.publicationDate = publicationDate;
-    this.summary = summary;
   }
 }

--- a/src/main/java/com/perfact/be/domain/report/entity/ReportBadge.java
+++ b/src/main/java/com/perfact/be/domain/report/entity/ReportBadge.java
@@ -1,0 +1,36 @@
+package com.perfact.be.domain.report.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "report_badges")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportBadge {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "report_id")
+  private Long reportId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "badge_id")
+  private Badge badge;
+
+  public void setReportId(Long reportId) {
+    this.reportId = reportId;
+  }
+
+  public void setBadge(Badge badge) {
+    this.badge = badge;
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/entity/TrueScore.java
+++ b/src/main/java/com/perfact/be/domain/report/entity/TrueScore.java
@@ -1,0 +1,47 @@
+package com.perfact.be.domain.report.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "true_scores")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrueScore {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "true_score_id")
+  private Long trueScoreId;
+
+  @Column(name = "report_id")
+  private Long reportId;
+
+  @Column(name = "source_reliability")
+  private Integer sourceReliability;
+
+  @Column(name = "factual_basis")
+  private Integer factualBasis;
+
+  @Column(name = "ad_exaggeration")
+  private Integer adExaggeration;
+
+  @Column(name = "bias")
+  private Integer bias;
+
+  @Column(name = "article_structure")
+  private Integer articleStructure;
+
+  @Column(name = "overall_score")
+  private Integer overallScore;
+
+  public void setReportId(Long reportId) {
+    this.reportId = reportId;
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/repository/BadgeRepository.java
+++ b/src/main/java/com/perfact/be/domain/report/repository/BadgeRepository.java
@@ -1,0 +1,12 @@
+package com.perfact.be.domain.report.repository;
+
+import com.perfact.be.domain.report.entity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+  Optional<Badge> findByBadgeName(Badge.BadgeName badgeName);
+}

--- a/src/main/java/com/perfact/be/domain/report/repository/ReportBadgeRepository.java
+++ b/src/main/java/com/perfact/be/domain/report/repository/ReportBadgeRepository.java
@@ -1,0 +1,12 @@
+package com.perfact.be.domain.report.repository;
+
+import com.perfact.be.domain.report.entity.ReportBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReportBadgeRepository extends JpaRepository<ReportBadge, Long> {
+  List<ReportBadge> findByReportId(Long reportId);
+}

--- a/src/main/java/com/perfact/be/domain/report/repository/TrueScoreRepository.java
+++ b/src/main/java/com/perfact/be/domain/report/repository/TrueScoreRepository.java
@@ -1,0 +1,12 @@
+package com.perfact.be.domain.report.repository;
+
+import com.perfact.be.domain.report.entity.TrueScore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TrueScoreRepository extends JpaRepository<TrueScore, Long> {
+  Optional<TrueScore> findByReportId(Long reportId);
+}

--- a/src/main/java/com/perfact/be/domain/report/service/PromptService.java
+++ b/src/main/java/com/perfact/be/domain/report/service/PromptService.java
@@ -51,6 +51,9 @@ public class PromptService {
           - **광고 목적**: Directly encourages purchase with phrases like "purchase link", "inquiry", "first-come, first-served".
           - **과장 표현 다수**: Repeated use of extreme/definitive language like "miraculous", "100%", "guaranteed success for anyone".
 
+      ### Step 5: Generate Detailed Chatbot Priming Text
+      - **chatbot_context**: Generate a **detailed and clean plain text** priming text for a follow-up Q&A chatbot. **This text MUST NOT contain markdown characters like '#' or '*'**. Use simple line breaks and text labels (e.g., `[섹션 제목]`) for structure. For each of the 5 reliability criteria, you MUST state the assigned score and the full `reason` in the format `'항목명 (점수): 이유'`. Also, list the granted badges and their reasons.
+
       # Final JSON Output Structure
       Your final output MUST follow this structure precisely:
       {
@@ -90,7 +93,8 @@ public class PromptService {
           }
         ],
         "total_score": integer,
-        "ai_badges": [ "A mandatory array of 1-2 strings representing the most characteristic badges." ]
+        "ai_badges": [ "A mandatory array of 1-2 strings representing the most characteristic badges." ],
+        "chatbot_context": "A detailed and structured plain text summary of the analysis results, designed to be used as the initial context for a separate Q&A chatbot. It must not contain markdown characters."
       }
       """;
 
@@ -104,43 +108,44 @@ public class PromptService {
         "topic": "전남 무안과 함평 지역에 내린 극한호우로 인한 침수 피해 및 주민 대피 상황",
         "source": "연합뉴스",
         "summary": [
-          "2025년 8월 3일, 짧은 시간에 내린 폭우로 인해 전남 무안군과 함평군 일대에 침수가 발생하여 주민 대피령이 내려졌습니다.",
-          "무안군은 신촌저수지 월류 위험 및 무안읍소재지 침수를 알리며 주민과 차량의 신속한 대피를 요청했습니다.",
-          "함평군 역시 함평읍내 침수 상황을 알리며 안전한 곳으로의 즉시 대피를 안내했고, 무안공항에는 시간당 142.1mm의 많은 비가 기록되었습니다.",
-          "전라남도는 침수 피해 최소화를 위해 현황을 파악하며 상황을 예의주시하고 있다고 밝혔습니다."
+            "2025년 8월 3일, 짧은 시간에 내린 폭우로 인해 전남 무안군과 함평군 일대에 침수가 발생하여 주민 대피령이 내려졌습니다.",
+            "무안군은 신촌저수지 월류 위험 및 무안읍소재지 침수를 알리며 주민과 차량의 신속한 대피를 요청했습니다.",
+            "함평군 역시 함평읍내 침수 상황을 알리며 안전한 곳으로의 즉시 대피를 안내했고, 무안공항에는 시간당 142.1mm의 많은 비가 기록되었습니다.",
+            "전라남도는 침수 피해 최소화를 위해 현황을 파악하며 상황을 예의주시하고 있다고 밝혔습니다."
         ],
         "reliability_analysis": [
-          {
-            "category_name": "출처 신뢰성",
-            "score": 95,
-            "reason": "대한민국 주요 통신사인 '연합뉴스'의 보도이며, 기사 말미에 기자 이메일이 명시되어 있습니다."
-          },
-          {
-            "category_name": "사실 근거",
-            "score": 100,
-            "reason": "재난 문자 발송 시각, 지역별 강수량(mm) 등 검증 가능한 수치를 제시하고 지자체 관계자를 인용했습니다."
-          },
-          {
-            "category_name": "광고/과장 표현",
-            "score": 100,
-            "reason": "상업적 목적이나 감정을 자극하는 과장된 표현 없이 발생한 사건을 객관적으로 보도하고 있습니다."
-          },
-          {
-            "category_name": "편향성",
-            "score": 90,
-            "reason": "특정 입장에 치우치지 않고, 재난 상황과 관련 당국의 대응을 사실적으로 전달하는 데 집중합니다."
-          },
-          {
-            "category_name": "기사 형식",
-            "score": 95,
-            "reason": "제목과 본문이 명확하게 일치하며, 기사의 내용이 사실 중심으로 간결하게 구성되어 있습니다."
-          }
+            {
+                "category_name": "출처 신뢰성",
+                "score": 95,
+                "reason": "대한민국 주요 통신사인 '연합뉴스'의 보도이며, 기사 말미에 기자 이메일이 명시되어 있습니다."
+            },
+            {
+                "category_name": "사실 근거",
+                "score": 100,
+                "reason": "재난 문자 발송 시각, 지역별 강수량(mm) 등 검증 가능한 수치를 제시하고 지자체 관계자를 인용했습니다."
+            },
+            {
+                "category_name": "광고/과장 표현",
+                "score": 100,
+                "reason": "상업적 목적이나 감정을 자극하는 과장된 표현 없이 발생한 사건을 객관적으로 보도하고 있습니다."
+            },
+            {
+                "category_name": "편향성",
+                "score": 90,
+                "reason": "특정 입장에 치우치지 않고, 재난 상황과 관련 당국의 대응을 사실적으로 전달하는 데 집중합니다."
+            },
+            {
+                "category_name": "기사 형식",
+                "score": 95,
+                "reason": "제목과 본문이 명확하게 일치하며, 기사의 내용이 사실 중심으로 간결하게 구성되어 있습니다."
+            }
         ],
         "total_score": 96,
         "ai_badges": [
-          "공신력 있는 출처",
-          "주의 환기 우수"
-        ]
+            "공신력 있는 출처",
+            "주의 환기 우수"
+        ],
+        "chatbot_context": "[기사 분석 리포트 요약]\n이 기사는 '연합뉴스'에서 보도했으며, 총점 96점(매우 높음)으로 평가된 신뢰도 높은 기사입니다.\n\n[세부 평가 근거]\n출처 신뢰성 (95점): 대한민국 주요 통신사인 '연합뉴스'의 보도이며, 기사 말미에 기자 이메일이 명시되어 신뢰도가 높습니다.\n사실 근거 (100점): 재난 문자 발송 시각, 지역별 강수량(mm) 등 검증 가능한 수치를 제시하고 지자체 관계자를 인용하여 만점을 받았습니다.\n광고/과장 표현 (100점): 상업적 목적이나 감정을 자극하는 과장된 표현 없이 발생한 사건을 객관적으로 보도하고 있습니다.\n편향성 (90점): 특정 입장에 치우치지 않고, 재난 상황과 관련 당국의 대응을 사실적으로 전달하는 데 집중합니다.\n기사 형식 (95점): 제목과 본문이 명확하게 일치하며, 기사의 내용이 사실 중심으로 간결하게 구성되어 있습니다.\n\n[부여된 AI 배지]\n공신력 있는 출처: 주요 언론사인 연합뉴스에서 보도하여 부여되었습니다.\n주의 환기 우수: 재난 상황의 위험성을 구체적인 근거를 들어 알리고 있어 부여되었습니다.\n\n이 내용을 기반으로 사용자의 질문에 상세히 답변하세요."
       }
       """;
 
@@ -189,20 +194,17 @@ public class PromptService {
         "total_score": 85,
         "ai_badges": [
           "광고성 기사"
-        ]
+        ],
+        "chatbot_context": "[기사 분석 리포트 요약]\n이 기사는 기자명('고윤상')은 명시되었으나 출처가 불분명하며, 총점 85점(높음)으로 평가되었습니다.\n\n[세부 평가 근거]\n출처 신뢰성 (65점): 기자 이름('고윤상')이 명시되어 있으나, 기사를 보도한 구체적인 언론사 이름이 확인되지 않아 보통 수준의 점수를 받았습니다.\n사실 근거 (95점): 프로모션 기간, 가격, 대상 브랜드 등 구체적이고 확인 가능한 사실 정보를 중심으로 내용을 구성하여 높은 점수를 받았습니다.\n광고/과장 표현 (90점): 기업의 할인 행사를 객관적으로 보도하고 있으며, 구매를 직접 유도하는 과장된 광고성 표현은 없습니다.\n편향성 (80점): 단순 행사 정보를 넘어, 기업의 전략적 배경과 의도(이미지 회복 등)를 함께 설명하며 다각적인 분석을 제공합니다.\n기사 형식 (95점): 제목이 기사의 핵심 내용을 잘 요약하고 있으며, 문단 구분이 명확하여 가독성이 높습니다.\n\n[부여된 AI 배지]\n광고성 기사: 기사의 핵심 주제가 특정 기업의 상품 할인 프로모션에 관한 것이므로 부여되었습니다.\n\n이 내용을 기반으로 사용자의 질문에 상세히 답변하세요."
       }
       """;
 
-  /**
-   * 시스템 프롬프트를 반환합니다.
-   */
+  // 시스템 프롬프트 반환
   public String getSystemPrompt() {
     return SYSTEM_PROMPT;
   }
 
-  /**
-   * 예시 대화들을 반환합니다.
-   */
+  // 예시 대화들 반환
   public List<ClovaRequestDTO.Message> getExampleConversations() {
     List<ClovaRequestDTO.Message> messages = new ArrayList<>();
 

--- a/src/main/java/com/perfact/be/domain/report/service/ReportService.java
+++ b/src/main/java/com/perfact/be/domain/report/service/ReportService.java
@@ -4,10 +4,9 @@ import com.perfact.be.domain.report.entity.Report;
 import com.perfact.be.domain.user.entity.User;
 
 public interface ReportService {
-
-  // 뉴스를 Clova API로 분석
   Object analyzeNewsWithClova(String url);
 
-  // 리포트 생성
-  Report createReport(User user, String url, Object analysisResult);
+  Report createReportFromAnalysis(Object analysisResult, String url, User user);
+
+  Report analyzeNewsAndCreateReport(String url, User user);
 }

--- a/src/main/java/com/perfact/be/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/report/service/ReportServiceImpl.java
@@ -4,15 +4,22 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import com.perfact.be.domain.news.service.NewsService;
+import com.perfact.be.domain.report.converter.ClovaAnalysisConverter;
 import com.perfact.be.domain.report.dto.ClovaRequestDTO;
 import com.perfact.be.domain.report.dto.ClovaResponseDTO;
+import com.perfact.be.domain.report.entity.Badge;
 import com.perfact.be.domain.report.entity.Report;
+import com.perfact.be.domain.report.entity.ReportBadge;
+import com.perfact.be.domain.report.entity.TrueScore;
+import com.perfact.be.domain.report.repository.BadgeRepository;
+import com.perfact.be.domain.report.repository.ReportBadgeRepository;
 import com.perfact.be.domain.report.repository.ReportRepository;
-import com.perfact.be.domain.report.converter.ReportConverter;
+import com.perfact.be.domain.report.repository.TrueScoreRepository;
+import com.perfact.be.domain.report.exception.ReportHandler;
 import com.perfact.be.domain.report.exception.status.ReportErrorStatus;
 import com.perfact.be.domain.user.entity.User;
-import com.perfact.be.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -20,18 +27,23 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ReportServiceImpl implements ReportService {
 
   private final NewsService newsService;
   private final ReportRepository reportRepository;
-  private final ReportConverter reportConverter;
+  private final BadgeRepository badgeRepository;
+  private final TrueScoreRepository trueScoreRepository;
+  private final ReportBadgeRepository reportBadgeRepository;
+  private final ClovaAnalysisConverter clovaAnalysisConverter;
   private final RestTemplate restTemplate;
   private final ObjectMapper objectMapper;
   private final PromptService promptService;
@@ -51,7 +63,105 @@ public class ReportServiceImpl implements ReportService {
         return analyzeOtherNewsSite(url);
       }
     } catch (Exception e) {
-      throw new GeneralException(ReportErrorStatus.CLOVA_API_CALL_FAILED);
+      log.error("Clova API 분석 실패 - URL: {}, 에러: {}", url, e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.CLOVA_API_CALL_FAILED);
+    }
+  }
+
+  @Override
+  @Transactional
+  public Report createReportFromAnalysis(Object analysisResult, String url, User user) {
+    try {
+      // 1. 뉴스 데이터 추출
+      NewsArticleResponse newsData;
+      if (newsService.isNaverNewsDomain(url)) {
+        newsData = newsService.extractNaverNewsArticle(url);
+      } else {
+        String title = newsService.extractTitleFromOtherNewsSites(url);
+        String content = newsService.extractNewsArticleContent(url);
+        newsData = new NewsArticleResponse(title, "날짜 정보 없음", content);
+      }
+
+      // 2. 분석 결과를 JSON 문자열로 변환
+      log.debug("분석 결과 객체 타입: {}", analysisResult.getClass().getSimpleName());
+      String analysisResultJson = objectMapper.writeValueAsString(analysisResult);
+      log.debug("변환된 JSON 문자열: {}", analysisResultJson);
+
+      // 3. Report 엔티티 생성 및 저장
+      Report report = clovaAnalysisConverter.convertToReport(analysisResultJson, newsData, user, url);
+      Report savedReport = reportRepository.save(report);
+
+      // 4. TrueScore 엔티티 생성 및 저장
+      TrueScore trueScore = clovaAnalysisConverter.convertToTrueScore(analysisResultJson);
+      trueScore.setReportId(savedReport.getReportId());
+      TrueScore savedTrueScore = trueScoreRepository.save(trueScore);
+
+      // 5. ReportBadge 엔티티들 생성 및 저장
+      List<ReportBadge> reportBadges = clovaAnalysisConverter.convertToReportBadges(analysisResultJson);
+      for (ReportBadge reportBadge : reportBadges) {
+        // Badge가 이미 존재하는지 확인하고 없으면 저장
+        Badge badge = reportBadge.getBadge();
+        Badge savedBadge = badgeRepository.findByBadgeName(badge.getBadgeName())
+            .orElseGet(() -> badgeRepository.save(badge));
+
+        reportBadge.setBadge(savedBadge);
+        reportBadge.setReportId(savedReport.getReportId());
+        ReportBadge savedReportBadge = reportBadgeRepository.save(reportBadge);
+      }
+
+      return savedReport;
+    } catch (Exception e) {
+      log.error("분석 결과로부터 리포트 생성 실패 - URL: {}, 사용자: {}, 에러: {}", url, user.getId(), e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CREATION_FAILED);
+    }
+  }
+
+  @Override
+  @Transactional
+  public Report analyzeNewsAndCreateReport(String url, User user) {
+    try {
+      // 1. 뉴스 데이터 추출
+      NewsArticleResponse newsData;
+      if (newsService.isNaverNewsDomain(url)) {
+        newsData = newsService.extractNaverNewsArticle(url);
+      } else {
+        String title = newsService.extractTitleFromOtherNewsSites(url);
+        String content = newsService.extractNewsArticleContent(url);
+        newsData = new NewsArticleResponse(title, "날짜 정보 없음", content);
+      }
+
+      // 2. Clova API 분석 수행
+      Object analysisResult = analyzeNewsWithClova(url);
+      log.debug("분석 결과 객체 타입: {}", analysisResult.getClass().getSimpleName());
+      String analysisResultJson = objectMapper.writeValueAsString(analysisResult);
+      log.debug("변환된 JSON 문자열: {}", analysisResultJson);
+
+      // 3. Report 엔티티 생성 및 저장
+      Report report = clovaAnalysisConverter.convertToReport(analysisResultJson, newsData, user, url);
+      Report savedReport = reportRepository.save(report);
+
+      // 4. TrueScore 엔티티 생성 및 저장
+      TrueScore trueScore = clovaAnalysisConverter.convertToTrueScore(analysisResultJson);
+      trueScore.setReportId(savedReport.getReportId());
+      TrueScore savedTrueScore = trueScoreRepository.save(trueScore);
+
+      // 5. ReportBadge 엔티티들 생성 및 저장
+      List<ReportBadge> reportBadges = clovaAnalysisConverter.convertToReportBadges(analysisResultJson);
+      for (ReportBadge reportBadge : reportBadges) {
+        // Badge가 이미 존재하는지 확인하고 없으면 저장
+        Badge badge = reportBadge.getBadge();
+        Badge savedBadge = badgeRepository.findByBadgeName(badge.getBadgeName())
+            .orElseGet(() -> badgeRepository.save(badge));
+
+        reportBadge.setBadge(savedBadge);
+        reportBadge.setReportId(savedReport.getReportId());
+        ReportBadge savedReportBadge = reportBadgeRepository.save(reportBadge);
+      }
+
+      return savedReport;
+    } catch (Exception e) {
+      log.error("리포트 생성 실패 - URL: {}, 사용자: {}, 에러: {}", url, user.getId(), e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.REPORT_CREATION_FAILED);
     }
   }
 
@@ -62,7 +172,8 @@ public class ReportServiceImpl implements ReportService {
       ClovaResponseDTO response = callClovaAPI(request);
       return parseJsonResponse(response.getResult().getMessage().getContent());
     } catch (Exception e) {
-      throw new GeneralException(ReportErrorStatus.CLOVA_API_CALL_FAILED);
+      log.error("네이버 뉴스 분석 실패 - URL: {}, 에러: {}", url, e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.CLOVA_API_CALL_FAILED);
     }
   }
 
@@ -76,12 +187,18 @@ public class ReportServiceImpl implements ReportService {
       ClovaResponseDTO response = callClovaAPI(request);
       return parseJsonResponse(response.getResult().getMessage().getContent());
     } catch (Exception e) {
-      throw new GeneralException(ReportErrorStatus.CLOVA_API_CALL_FAILED);
+      log.error("기타 뉴스 사이트 분석 실패 - URL: {}, 에러: {}", url, e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.CLOVA_API_CALL_FAILED);
     }
   }
 
   private Object parseJsonResponse(String analysisResult) {
     try {
+      // 원본 응답 로깅
+      log.debug("=== 원본 Clova 응답 ===");
+      log.debug("analysisResult 길이: {}", analysisResult != null ? analysisResult.length() : "null");
+      log.debug("analysisResult: {}", analysisResult);
+
       // ```json ... ``` 형태의 마크다운 코드 블록 제거
       String jsonContent = analysisResult;
       if (jsonContent.startsWith("```json")) {
@@ -94,16 +211,36 @@ public class ReportServiceImpl implements ReportService {
       // 앞뒤 공백 제거
       jsonContent = jsonContent.trim();
 
-      // JSON 파싱하여 객체로 변환 (UTF-8 인코딩 명시)
+      // JSON 구조 검증
+      log.debug("=== JSON 구조 검증 ===");
+      log.debug("처리된 JSON 내용 길이: {}", jsonContent.length());
+      log.debug("처리된 JSON 내용: {}", jsonContent);
+
+      // JSON 구조가 올바른지 미리 검증
+      if (!jsonContent.startsWith("{") || !jsonContent.endsWith("}")) {
+        log.error("JSON 구조가 올바르지 않습니다. 시작: {}, 끝: {}",
+            jsonContent.length() > 0 ? jsonContent.charAt(0) : "empty",
+            jsonContent.length() > 0 ? jsonContent.charAt(jsonContent.length() - 1) : "empty");
+        throw new ReportHandler(ReportErrorStatus.ANALYSIS_RESULT_PARSING_FAILED);
+      }
+
+      // JSON 파싱하여 객체로 변환 (더 강력한 인코딩 처리)
       ObjectMapper mapper = new ObjectMapper();
       mapper.configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
       mapper.configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
+      mapper.configure(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER, true);
+
+      // UTF-8로 명시적 인코딩하여 파싱
       Object jsonObject = mapper.readValue(jsonContent.getBytes("UTF-8"), Object.class);
 
+      log.debug("JSON 파싱 성공");
       return jsonObject;
     } catch (Exception e) {
-      // 파싱 실패 시 원본 문자열 반환
-      return analysisResult;
+      log.error("JSON 파싱 실패 - 원본 내용: {}", analysisResult);
+      log.error("JSON 파싱 실패 - 에러: {}", e.getMessage(), e);
+
+      // 파싱 실패 시 예외를 던져서 상위에서 처리하도록 함
+      throw new ReportHandler(ReportErrorStatus.ANALYSIS_RESULT_PARSING_FAILED);
     }
   }
 
@@ -148,35 +285,15 @@ public class ReportServiceImpl implements ReportService {
       try {
         responseBody = objectMapper.readValue(response.getBody(), ClovaResponseDTO.class);
       } catch (Exception e) {
-        throw new GeneralException(ReportErrorStatus.ANALYSIS_RESULT_PARSING_FAILED);
+        log.error("Clova API 응답 파싱 실패: {}", e.getMessage(), e);
+        throw new ReportHandler(ReportErrorStatus.ANALYSIS_RESULT_PARSING_FAILED);
       }
 
       return responseBody;
 
     } catch (Exception e) {
-      throw new GeneralException(ReportErrorStatus.CLOVA_API_CALL_FAILED);
-    }
-  }
-
-  @Override
-  public Report createReport(User user, String url, Object analysisResult) {
-    try {
-      NewsArticleResponse newsData;
-      if (newsService.isNaverNewsDomain(url)) {
-        newsData = newsService.extractNaverNewsArticle(url);
-      } else {
-        String title = newsService.extractTitleFromOtherNewsSites(url);
-        String content = newsService.extractNewsArticleContent(url);
-        newsData = new NewsArticleResponse(title, "날짜 정보 없음", content);
-      }
-
-      ClovaResponseDTO clovaResponse = objectMapper.convertValue(analysisResult, ClovaResponseDTO.class);
-
-      Report report = reportConverter.toReport(clovaResponse, newsData, user, url);
-
-      return reportRepository.save(report);
-    } catch (Exception e) {
-      throw new GeneralException(ReportErrorStatus.REPORT_CREATION_FAILED);
+      log.error("Clova API 호출 실패: {}", e.getMessage(), e);
+      throw new ReportHandler(ReportErrorStatus.CLOVA_API_CALL_FAILED);
     }
   }
 }

--- a/src/main/java/com/perfact/be/domain/report/util/ClovaResponseParser.java
+++ b/src/main/java/com/perfact/be/domain/report/util/ClovaResponseParser.java
@@ -1,0 +1,43 @@
+package com.perfact.be.domain.report.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ClovaResponseParser {
+
+  // Clova API 응답에서 카테고리(field) 추출
+  public String extractCategory(String content) {
+    try {
+      if (content.contains("\"field\"")) {
+        int start = content.indexOf("\"field\"") + 8;
+        int end = content.indexOf("\"", start);
+        if (start > 7 && end > start) {
+          return content.substring(start, end);
+        }
+      }
+      return "기타";
+    } catch (Exception e) {
+      log.warn("카테고리 추출 실패: {}", e.getMessage());
+      return "기타";
+    }
+  }
+
+  // Clova API 응답에서 요약(summary) 추출
+  public String extractSummary(String content) {
+    try {
+      if (content.contains("\"summary\"")) {
+        int start = content.indexOf("\"summary\"") + 10;
+        int end = content.indexOf("]", start);
+        if (start > 9 && end > start) {
+          return content.substring(start, end).replaceAll("\"", "").replaceAll(",", "\n");
+        }
+      }
+      return "";
+    } catch (Exception e) {
+      log.warn("요약 추출 실패: {}", e.getMessage());
+      return "";
+    }
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/util/DateParser.java
+++ b/src/main/java/com/perfact/be/domain/report/util/DateParser.java
@@ -1,0 +1,24 @@
+package com.perfact.be.domain.report.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+public class DateParser {
+
+  // 날짜 문자열을 LocalDate로 변환
+  public LocalDate parsePublicationDate(String dateStr) {
+    try {
+      if (dateStr == null || dateStr.equals("날짜 정보 없음")) {
+        return LocalDate.now();
+      }
+      return LocalDate.parse(dateStr.substring(0, 10));
+    } catch (Exception e) {
+      log.warn("날짜 파싱 실패 - dateStr: {}, 에러: {}", dateStr, e.getMessage());
+      return LocalDate.now();
+    }
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/util/UrlParser.java
+++ b/src/main/java/com/perfact/be/domain/report/util/UrlParser.java
@@ -1,0 +1,20 @@
+package com.perfact.be.domain.report.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class UrlParser {
+
+  // URL에서 출처(도메인) 정보 추출
+  public String extractPublisher(String url) {
+    try {
+      String domain = url.replaceAll("https?://", "").replaceAll("www\\.", "");
+      return domain.split("/")[0];
+    } catch (Exception e) {
+      log.warn("출처 추출 실패 - URL: {}, 에러: {}", url, e.getMessage());
+      return "unknown";
+    }
+  }
+}


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#9 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
1. Converter 분리
ClovaResponseParser: JSON 응답에서 카테고리, 요약 추출 로직 분리
UrlParser: URL에서 출판사 정보 추출 로직 분리
DateParser: 날짜 문자열 변환 로직 분리
ReportConverter: 이제 변환 책임만 담당

2. 예외 처리 개선
Handler + ErrorStatus 조합: ReportHandler(ReportErrorStatus.XXX) 사용
적절한 로깅: log.error(), log.warn() 추가
구체적인 에러 메시지: URL, 사용자 ID 등 컨텍스트 정보 포함

3. DTO 명세 추가
NewsArticleResponse: Swagger @Schema 어노테이션 추가
ClovaResponseDTO: 모든 필드에 상세한 설명과 예시 추가
프론트엔드 친화적: 각 필드의 의미와 형식 명확히 정의

4. JsonParseException 문제 해결
강화된 JSON 파싱 로직: 원본 응답 상세 로깅 및 JSON 구조 검증 추가
에러 추적성 향상: 원본 응답 길이, 내용, 처리 과정을 단계별로 로깅
사전 검증 로직: 시작/끝 괄호 확인으로 잘못된 JSON 구조 차단

5. API 응답 구조 개선
완전한 리포트 정보 제공: ReportResponseDto로 Report, TrueScore, ReportBadge 정보 통합
Swagger 문서화 강화: 모든 DTO 필드에 @Schema 어노테이션으로 상세 설명 추가
프론트엔드 친화적 응답: 점수 정보와 AI 배지 정보를 포함한 완전한 분석 결과 제공

6. 데이터 타입 안정성 개선

7. 프롬프트 수정

8. 엔티티 코드 수정
ERD 기반 엔티티 코드 수정

9. 기타 사항 개선
import 정리: 패키지 경로 직접 작성 없이 import 사용
로깅 보완: 모든 catch 블록에 적절한 로깅 추가
에러 추적성 향상: 스택 트레이스와 컨텍스트 정보 포함


### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->