### PR TITLE
Feat : 리프레시 토큰 기반 로그아웃 및 엑세스 토큰 재발급 구현

### DIFF
--- a/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.perfact.be.global.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -53,7 +54,7 @@ public class AuthController {
   )
   @PostMapping(value = "/refresh", produces = "application/json")
   public ApiResponse<AuthResponseDto.TokenResponse> refreshAccessToken(
-      @RequestBody AuthRequestDto.RefreshTokenRequest request,
+      @Valid @RequestBody AuthRequestDto.RefreshTokenRequest request,
       @CurrentUser @Parameter(hidden = true)User loginUser) {
     AuthResponseDto.TokenResponse response = authService.refreshAccessToken(loginUser, request.getRefreshToken());
     return ApiResponse.of(AuthSuccessStatus.AT_REFRESH_SUCCESS, response);
@@ -65,7 +66,7 @@ public class AuthController {
   )
   @PostMapping(value = "/logout", produces = "application/json")
   public ApiResponse<Void> logout(
-      @RequestBody AuthRequestDto.RefreshTokenRequest request,
+      @Valid @RequestBody AuthRequestDto.RefreshTokenRequest request,
       @CurrentUser @Parameter(hidden = true) User loginUser ) {
     authService.logout(loginUser, request.getRefreshToken());
     return ApiResponse.of(AuthSuccessStatus.LOGOUT_SUCCESS, null);

--- a/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
@@ -1,20 +1,22 @@
 package com.perfact.be.domain.auth.controller;
 
+import com.perfact.be.domain.auth.dto.AuthRequestDto;
 import com.perfact.be.domain.auth.dto.AuthResponseDto;
 import com.perfact.be.domain.auth.exception.status.AuthSuccessStatus;
 import com.perfact.be.domain.auth.service.AuthService;
+import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.global.apiPayload.ApiResponse;
+import com.perfact.be.global.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.service.GenericResponseService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.support.StandardServletMultipartResolver;
 
 @Tag(name="Auth", description = "인증 관련 API")
 @RestController
@@ -44,6 +46,31 @@ public class AuthController {
     AuthResponseDto.LoginResponse response = authService.socialLogin(code, state);
     return ApiResponse.of(AuthSuccessStatus.SOCIAL_LOGIN_SUCCESS, response);
   }
+
+  @Operation(
+      summary = "엑세스 토큰 재발급",
+      description = "리프레시 토큰을 이용해 엑세스 토큰을 재발급합니다."
+  )
+  @PostMapping(value = "/refresh", produces = "application/json")
+  public ApiResponse<AuthResponseDto.TokenResponse> refreshAccessToken(
+      @RequestBody AuthRequestDto.RefreshTokenRequest request,
+      @CurrentUser @Parameter(hidden = true)User loginUser) {
+    AuthResponseDto.TokenResponse response = authService.refreshAccessToken(loginUser, request.getRefreshToken());
+    return ApiResponse.of(AuthSuccessStatus.AT_REFRESH_SUCCESS, response);
+  }
+
+  @Operation(
+      summary = "로그아웃",
+      description = "현재 로그인한 사용자의 리프레시 토큰을 삭제하고 로그아웃 처리합니다."
+  )
+  @PostMapping(value = "/logout", produces = "application/json")
+  public ApiResponse<Void> logout(
+      @RequestBody AuthRequestDto.RefreshTokenRequest request,
+      @CurrentUser @Parameter(hidden = true) User loginUser ) {
+    authService.logout(loginUser, request.getRefreshToken());
+    return ApiResponse.of(AuthSuccessStatus.LOGOUT_SUCCESS, null);
+  }
+
 
 
 

--- a/src/main/java/com/perfact/be/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/com/perfact/be/domain/auth/controller/DevAuthController.java
@@ -2,9 +2,7 @@ package com.perfact.be.domain.auth.controller;
 
 import com.perfact.be.domain.auth.exception.status.AuthSuccessStatus;
 import com.perfact.be.domain.auth.service.DevAuthService;
-import com.perfact.be.domain.user.exception.status.UserSuccessStatus;
 import com.perfact.be.global.apiPayload.ApiResponse;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/perfact/be/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/perfact/be/domain/auth/dto/AuthRequestDto.java
@@ -1,0 +1,23 @@
+package com.perfact.be.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthRequestDto {
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Schema(description = "로그아웃 및 액세스 토큰 재발급 요청 DTO")
+  public static class RefreshTokenRequest {
+    @NotNull
+    @Schema(
+        description = "JWT 리프레시 토큰",
+        example = "easdasdadasdasdasdasdasd..."
+    )
+    private String refreshToken;
+  }
+
+}

--- a/src/main/java/com/perfact/be/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/perfact/be/domain/auth/dto/AuthRequestDto.java
@@ -1,6 +1,7 @@
 package com.perfact.be.domain.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +13,7 @@ public class AuthRequestDto {
   @NoArgsConstructor
   @Schema(description = "로그아웃 및 액세스 토큰 재발급 요청 DTO")
   public static class RefreshTokenRequest {
-    @NotNull
+    @NotBlank
     @Schema(
         description = "JWT 리프레시 토큰",
         example = "easdasdadasdasdasdasdasd..."

--- a/src/main/java/com/perfact/be/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/perfact/be/domain/auth/dto/AuthResponseDto.java
@@ -18,7 +18,18 @@ public class AuthResponseDto {
     private String email;
 
     @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
-    private String token;
+    private String accessToken;
+
+    @Schema(description = "JWT 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
+    private String refreshToken;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @Schema(description = "엑세스 토큰 재생성 응답 DTO")
+  public static class TokenResponse {
+    @Schema(description = "새로 발급된 JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
+    private String accessToken;
   }
 
 }

--- a/src/main/java/com/perfact/be/domain/auth/exception/status/AuthErrorStatus.java
+++ b/src/main/java/com/perfact/be/domain/auth/exception/status/AuthErrorStatus.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorStatus implements BaseErrorCode {
   NAVER_TOKEN_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_4001", "네이버 Access Token 요청 실패"),
-  NAVER_USERINFO_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_4002", "네이버 사용자 정보 요청 실패");
+  INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "RT_4001","유효하지 않은 리프레시 토큰입니다."),
+  NAVER_USERINFO_REQUEST_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_4002", "네이버 사용자 정보 요청 실패"),
+  USER_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH_4003","해당 토큰에 대한 접근 권한이 없습니다." );
 
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/perfact/be/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/com/perfact/be/domain/auth/exception/status/AuthSuccessStatus.java
@@ -11,9 +11,9 @@ import org.springframework.http.HttpStatus;
 public enum AuthSuccessStatus implements BaseCode {
 
   SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 완료되었습니다."),
-  DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다.")
-
-  ;
+  DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다."),
+  LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃이 완료되었습니다."),
+  AT_REFRESH_SUCCESS(HttpStatus.OK, "AUTH2004", "엑세스 토큰 재생성이 완료되었습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/perfact/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/perfact/be/domain/auth/service/AuthService.java
@@ -1,8 +1,15 @@
 package com.perfact.be.domain.auth.service;
 
 import com.perfact.be.domain.auth.dto.AuthResponseDto;
+import com.perfact.be.domain.auth.dto.AuthResponseDto.TokenResponse;
+import com.perfact.be.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
 
 public interface AuthService {
 
   AuthResponseDto.LoginResponse socialLogin(String code, String state);
+
+  TokenResponse refreshAccessToken(User loginUser, String refreshToken);
+
+  void logout(User loginUser, String refreshToken);
 }

--- a/src/main/java/com/perfact/be/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/auth/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.perfact.be.domain.auth.service;
 
 import com.perfact.be.domain.auth.dto.AuthResponseDto;
+import com.perfact.be.domain.auth.dto.AuthResponseDto.TokenResponse;
 import com.perfact.be.domain.auth.dto.NaverTokenResponse;
 import com.perfact.be.domain.auth.dto.NaverUserInfoResponse;
 import com.perfact.be.domain.auth.dto.NaverUserProfile;
@@ -9,8 +10,12 @@ import com.perfact.be.domain.auth.exception.status.AuthErrorStatus;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.domain.user.service.UserService;
 import com.perfact.be.global.jwt.JwtProvider;
+import jakarta.annotation.Resource;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -24,6 +29,9 @@ public class AuthServiceImpl implements AuthService {
   private final UserService userService;
   private final JwtProvider jwtProvider;
 
+  @Resource(name = "rtRedisTemplate")
+  private RedisTemplate<String, String> redisTemplate;
+
   @Value("${naver.client-id}")
   private String clientId;
 
@@ -35,13 +43,48 @@ public class AuthServiceImpl implements AuthService {
 
   @Override
   public AuthResponseDto.LoginResponse socialLogin(String code, String state) {
-    String accessToken = getAccessToken(code, state);
-    NaverUserProfile profile = getUserProfile(accessToken);
+    String naverAccessToken = getAccessToken(code, state);
+    NaverUserProfile profile = getUserProfile(naverAccessToken);
     User user = userService.findOrCreateUser(profile);
-    String token = jwtProvider.generateToken(user.getId(), user.getEmail());
+    String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getSocialId());
 
-    return new AuthResponseDto.LoginResponse(user.getId(), user.getEmail(), token);
+    String uuid = UUID.randomUUID().toString();
+    String refreshToken = jwtProvider.generateRefreshToken(user.getId(), user.getSocialId(), uuid);
+
+    String redisKey = "RT:" + user.getSocialId() + ":" + uuid;
+    redisTemplate.opsForValue().set(redisKey, refreshToken, 3, TimeUnit.HOURS);
+
+    return new AuthResponseDto.LoginResponse(user.getId(), user.getEmail(), accessToken, refreshToken);
   }
+
+  @Override
+  public TokenResponse refreshAccessToken(User loginUser, String refreshToken) {
+    // 1. 토큰 유효성 검증 (서명, 만료, 타입)
+    jwtProvider.validateRefreshToken(refreshToken);
+
+    validateTokenUserMatch(refreshToken, loginUser);
+
+    String redisKey = buildRedisKeyFromToken(refreshToken);
+    String storedToken = redisTemplate.opsForValue().get(redisKey);
+
+    if (storedToken == null || !storedToken.equals(refreshToken)) {
+      throw new AuthHandler(AuthErrorStatus.INVALID_REFRESH_TOKEN);
+    }
+
+    // AccessToken 재발급 TODO : RTR 은 후순위..
+    String newAccessToken = jwtProvider.generateAccessToken(loginUser.getId(), loginUser.getSocialId());
+    return new TokenResponse(newAccessToken);
+  }
+
+  @Override
+  public void logout(User loginUser, String refreshToken) {
+    jwtProvider.validateRefreshToken(refreshToken);
+    validateTokenUserMatch(refreshToken, loginUser);
+
+    String redisKey = buildRedisKeyFromToken(refreshToken);
+    redisTemplate.delete(redisKey);
+  }
+
 
   private String getAccessToken(String code, String state) {
     NaverTokenResponse tokenResponse = webClient
@@ -91,5 +134,18 @@ public class AuthServiceImpl implements AuthService {
     }
 
     return userInfoResponse.getResponse();
+  }
+
+  private void validateTokenUserMatch(String refreshToken, User loginUser) {
+    Long userIdFromToken = jwtProvider.getUserIdFromToken(refreshToken);
+    if (!userIdFromToken.equals(loginUser.getId())) {
+      throw new AuthHandler(AuthErrorStatus.USER_TOKEN_MISMATCH);
+    }
+  }
+
+  private String buildRedisKeyFromToken(String refreshToken) {
+    String uuid = jwtProvider.getUuidFromToken(refreshToken);
+    String socialId = jwtProvider.getSocialIdFromToken(refreshToken);
+    return "RT:" + socialId + ":" + uuid;
   }
 }

--- a/src/main/java/com/perfact/be/domain/auth/service/DevAuthService.java
+++ b/src/main/java/com/perfact/be/domain/auth/service/DevAuthService.java
@@ -35,7 +35,7 @@ public class DevAuthService {
         .build();
 
     userRepository.save(fakeUser);
-    return jwtProvider.generateToken(fakeUser.getId(), fakeUser.getSocialId());
+    return jwtProvider.generateAccessToken(fakeUser.getId(), fakeUser.getSocialId());
   }
 }
 

--- a/src/main/java/com/perfact/be/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/perfact/be/global/jwt/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     if (token != null) {
       try {
-        jwtProvider.validateToken(token);
+        jwtProvider.validateAccessToken(token);
         Authentication authentication = jwtProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);
 


### PR DESCRIPTION
### 관련 이슈
#11 

- 다중 세션 지원
- 로그아웃 및 AT 재발급 기능 구현

### 작업한 내용

- RT 생성 시 UUID 포함 및 "RT:{socialId}:{uuid}" 형태로 Redis 저장
- 로그아웃 시 해당 RT만 삭제
- AT 재발급 시 유저 일치 여부 및 Redis 내 RT 검증 추가
- 요청 DTO에 @Valid 적용으로 입력값 유효성 검증 강화

### PR Point 및 참고사항
RTR(Refresh Token Rotation)은 미적용 (후순위 예정)
관련 유효성 검사 결과와 스웨거 테스트는 노션에 자세하게 작성해두었습니다.