### PR TITLE
Feat : 과거 레포트 조회 API 구현

### DIFF
--- a/src/main/java/com/perfact/be/domain/report/converter/ReportConverter.java
+++ b/src/main/java/com/perfact/be/domain/report/converter/ReportConverter.java
@@ -2,6 +2,7 @@ package com.perfact.be.domain.report.converter;
 
 import com.perfact.be.domain.news.dto.NewsArticleResponse;
 import com.perfact.be.domain.report.dto.ClovaResponseDTO;
+import com.perfact.be.domain.report.dto.ReportResponseDto;
 import com.perfact.be.domain.report.entity.Report;
 import com.perfact.be.domain.report.exception.ReportHandler;
 import com.perfact.be.domain.report.exception.status.ReportErrorStatus;
@@ -9,8 +10,10 @@ import com.perfact.be.domain.report.util.ClovaResponseParser;
 import com.perfact.be.domain.report.util.DateParser;
 import com.perfact.be.domain.report.util.UrlParser;
 import com.perfact.be.domain.user.entity.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -45,4 +48,29 @@ public class ReportConverter {
       throw new ReportHandler(ReportErrorStatus.REPORT_CONVERSION_FAILED);
     }
   }
+
+  public ReportResponseDto.ReportDto toDto(Report report) {
+    return ReportResponseDto.ReportDto.builder()
+        .reportId(report.getReportId())
+        .title(report.getTitle())
+        .createdAt(report.getCreatedAt())
+        .build();
+  }
+
+  public List<ReportResponseDto.ReportDto> toDtoList(List<Report> reports) {
+    return reports.stream()
+        .map(this::toDto)
+        .toList();
+  }
+
+  public ReportResponseDto.ReportListDto toListDto(Page<Report> reportsPage) {
+    return ReportResponseDto.ReportListDto.builder()
+        .reports(toDtoList(reportsPage.getContent()))
+        .currentPage(reportsPage.getNumber() + 1)
+        .totalPages(reportsPage.getTotalPages())
+        .totalElements(reportsPage.getTotalElements())
+        .isLast(reportsPage.isLast())
+        .build();
+  }
+
 }

--- a/src/main/java/com/perfact/be/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/com/perfact/be/domain/report/dto/ReportResponseDto.java
@@ -136,4 +136,45 @@ public class ReportResponseDto {
           .build();
     }
   }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "레포트 리스트 응답 DTO")
+  public static class ReportListDto {
+
+    @Schema(description = "레포트 목록")
+    private List<ReportDto> reports;
+
+    @Schema(description = "현재 페이지 번호 (1부터 시작)", example = "1")
+    private int currentPage;
+
+    @Schema(description = "전체 페이지 수", example = "5")
+    private int totalPages;
+
+    @Schema(description = "전체 레포트 수", example = "27")
+    private long totalElements;
+
+    @Schema(description = "현재 페이지가 마지막 페이지 여부", example = "false")
+    private boolean isLast;
+  }
+
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(description = "리포트 응답 DTO")
+  public static class ReportDto {
+
+    @Schema(description = "리포트 ID", example = "1")
+    private Long reportId;
+
+    @Schema(description = "뉴스 제목", example = "뉴스 제목입니다")
+    private String title;
+
+    @Schema(description = "생성일시")
+    private LocalDateTime createdAt;
+  }
 }

--- a/src/main/java/com/perfact/be/domain/report/exception/status/ReportErrorStatus.java
+++ b/src/main/java/com/perfact/be/domain/report/exception/status/ReportErrorStatus.java
@@ -14,6 +14,7 @@ public enum ReportErrorStatus implements BaseErrorCode {
   ANALYSIS_RESULT_PARSING_FAILED(HttpStatus.BAD_REQUEST, "REPORT4003", "분석 결과 파싱에 실패했습니다."),
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4004", "리포트를 찾을 수 없습니다."),
   REPORT_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "REPORT4005", "리포트 변환에 실패했습니다."),
+  INVALID_PAGE_NUMBER(HttpStatus.NOT_FOUND, "REPORT4006","페이지 번호가 유효하지 않습니다.")
   ;
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/perfact/be/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/perfact/be/domain/report/repository/ReportRepository.java
@@ -2,6 +2,8 @@ package com.perfact.be.domain.report.repository;
 
 import com.perfact.be.domain.report.entity.Report;
 import com.perfact.be.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
   List<Report> findByUserOrderByCreatedAtDesc(User user);
 
   List<Report> findByUserAndCategoryOrderByCreatedAtDesc(User user, String category);
+
+  Page<Report> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 }

--- a/src/main/java/com/perfact/be/domain/report/service/ReportService.java
+++ b/src/main/java/com/perfact/be/domain/report/service/ReportService.java
@@ -1,5 +1,6 @@
 package com.perfact.be.domain.report.service;
 
+import com.perfact.be.domain.report.dto.ReportResponseDto.ReportListDto;
 import com.perfact.be.domain.report.entity.Report;
 import com.perfact.be.domain.user.entity.User;
 
@@ -9,4 +10,6 @@ public interface ReportService {
   Report createReportFromAnalysis(Object analysisResult, String url, User user);
 
   Report analyzeNewsAndCreateReport(String url, User user);
+
+  ReportListDto getSavedReports(User loginUser, int page);
 }

--- a/src/main/java/com/perfact/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/perfact/be/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.perfact.be.domain.user.controller;
 
+import com.perfact.be.domain.report.dto.ReportResponseDto;
+import com.perfact.be.domain.report.dto.ReportResponseDto.ReportListDto;
+import com.perfact.be.domain.report.service.ReportService;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.domain.user.exception.status.UserSuccessStatus;
 import com.perfact.be.domain.user.service.UserService;
@@ -11,8 +14,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name="User", description = "유저 관련 API")
@@ -21,6 +26,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/users")
 public class UserController {
   private final UserService userService;
+  private final ReportService reportService;
+
+  @Operation(
+      summary = "레포트 저장함 리스트 조회",
+      description = "현재 로그인한 사용자가 저장한 과거 레포트 리스트를 조회합니다. 페이지네이션이 적용되어 있으며, 페이지 번호는 1부터 시작합니다.",
+      parameters = {
+          @Parameter(name = "page", description = "페이지 번호 (1부터 시작)", example = "1"),
+      }
+  )
+  @GetMapping("/{reportId}")
+  public ApiResponse<ReportResponseDto.ReportListDto> getReportList(
+      @Parameter(hidden = true) @CurrentUser User loginUser,
+      @RequestParam(name = "page", defaultValue = "1") int page
+  ) {
+    ReportResponseDto.ReportListDto response = reportService.getSavedReports(loginUser, page);
+    return ApiResponse.of(UserSuccessStatus.GET_REPORT_LIST_SUCCESS, response);
+  }
 
   @Operation(summary = "구독 상태 확인", description = "현재 사용자의 구독 상태를 확인합니다.")
   @GetMapping("/subscribe")

--- a/src/main/java/com/perfact/be/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/com/perfact/be/domain/user/exception/status/UserSuccessStatus.java
@@ -13,7 +13,8 @@ public enum UserSuccessStatus implements BaseCode {
   SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "USER2001", "소셜 로그인이 완료되었습니다."),
   GET_SUBSCRIBE_STATUS_SUCCESS(HttpStatus.OK, "USER2002", "구독 상태 조회 성공"),
   SUBSCRIBE_SUCCESS(HttpStatus.OK, "USER2003", "구독 신청 성공"),
-  UNSUBSCRIBE_SUCCESS(HttpStatus.OK, "USER2004", "구독 해지 성공")
+  UNSUBSCRIBE_SUCCESS(HttpStatus.OK, "USER2004", "구독 해지 성공"),
+  GET_REPORT_LIST_SUCCESS(HttpStatus.OK, "USER2005","과거 레포트 리스트 조회 성공")
 
   ;
 


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#13 
- 사용자가 저장한 Report 목록을 최신순으로 조회하도록 Pageable 정렬 설정

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

- ReportServiceImpl.getSavedReports() 내 페이징 로직에 최신순 정렬 조건 추가
- 사용자가 저장한 Report 목록을 최신순으로 조회 가능하게 처리
- Report → ReportDto 변환 로직을 ReportConverter로 분리
- 페이지 번호 1부터 시작하도록 설정 및 관련 예외 처리 구현

### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
1. 올바르지 않은 페이지 번호를 입력했을때
<img width="379" height="102" alt="스크린샷 2025-08-07 오후 4 53 08" src="https://github.com/user-attachments/assets/c6da8626-3439-4532-a9a0-23480197bfe4" />

2. 과거 레포트 목록 조회에 성공했을때
<img width="834" height="339" alt="스크린샷 2025-08-07 오후 4 53 00" src="https://github.com/user-attachments/assets/759aaf5d-a61f-45af-9a57-efe335a065b4" />


