### PR TITLE
Feat : 과거 레포트 조회 API 구현

### DIFF
--- a/src/main/java/com/perfact/be/domain/report/exception/status/ReportErrorStatus.java
+++ b/src/main/java/com/perfact/be/domain/report/exception/status/ReportErrorStatus.java
@@ -14,8 +14,8 @@ public enum ReportErrorStatus implements BaseErrorCode {
   ANALYSIS_RESULT_PARSING_FAILED(HttpStatus.BAD_REQUEST, "REPORT4003", "분석 결과 파싱에 실패했습니다."),
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "REPORT4004", "리포트를 찾을 수 없습니다."),
   REPORT_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "REPORT4005", "리포트 변환에 실패했습니다."),
-  INVALID_PAGE_NUMBER(HttpStatus.NOT_FOUND, "REPORT4006","페이지 번호가 유효하지 않습니다.")
-  ;
+  INVALID_PAGE_NUMBER(HttpStatus.NOT_FOUND, "REPORT4006","페이지 번호가 유효하지 않습니다."),
+  FORBIDDEN_REPORT_ACCESS(HttpStatus.FORBIDDEN,"REPORT4007","해당 레포트에 접근 권한이 없습니다." );
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/perfact/be/domain/report/service/ReportService.java
+++ b/src/main/java/com/perfact/be/domain/report/service/ReportService.java
@@ -1,5 +1,7 @@
 package com.perfact.be.domain.report.service;
 
+import com.perfact.be.domain.report.dto.ReportResponseDto;
+import com.perfact.be.domain.report.dto.ReportResponseDto.ReportDto;
 import com.perfact.be.domain.report.dto.ReportResponseDto.ReportListDto;
 import com.perfact.be.domain.report.entity.Report;
 import com.perfact.be.domain.user.entity.User;
@@ -12,4 +14,6 @@ public interface ReportService {
   Report analyzeNewsAndCreateReport(String url, User user);
 
   ReportListDto getSavedReports(User loginUser, int page);
+
+  ReportResponseDto getReport(User loginUser, Long reportId);
 }

--- a/src/main/java/com/perfact/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/perfact/be/domain/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
           @Parameter(name = "page", description = "페이지 번호 (1부터 시작)", example = "1"),
       }
   )
-  @GetMapping("/{reportId}")
+  @GetMapping("")
   public ApiResponse<ReportResponseDto.ReportListDto> getReportList(
       @Parameter(hidden = true) @CurrentUser User loginUser,
       @RequestParam(name = "page", defaultValue = "1") int page
@@ -43,6 +43,28 @@ public class UserController {
     ReportResponseDto.ReportListDto response = reportService.getSavedReports(loginUser, page);
     return ApiResponse.of(UserSuccessStatus.GET_REPORT_LIST_SUCCESS, response);
   }
+
+
+  @Operation(
+      summary = "레포트 저장함에서 과거 레포트 조회",
+      description = "현재 로그인한 사용자가 생성한 특정 리포트(reportId)를 조회합니다.",
+      parameters = {
+          @Parameter(name = "reportId", description = "조회할 리포트 ID", example = "1")
+      }
+  )
+  @GetMapping("/{reportId}")
+  public ApiResponse<ReportResponseDto> getMyReport(
+      @Parameter(hidden = true) @CurrentUser User loginUser,
+      @PathVariable Long reportId
+  ) {
+    ReportResponseDto response = reportService.getReport(loginUser, reportId);
+    return ApiResponse.of(UserSuccessStatus.GET_REPORT_SUCCESS, response);
+  }
+
+
+
+
+  // TODO 해야됨
 
   @Operation(summary = "구독 상태 확인", description = "현재 사용자의 구독 상태를 확인합니다.")
   @GetMapping("/subscribe")

--- a/src/main/java/com/perfact/be/domain/user/exception/status/UserSuccessStatus.java
+++ b/src/main/java/com/perfact/be/domain/user/exception/status/UserSuccessStatus.java
@@ -14,8 +14,8 @@ public enum UserSuccessStatus implements BaseCode {
   GET_SUBSCRIBE_STATUS_SUCCESS(HttpStatus.OK, "USER2002", "구독 상태 조회 성공"),
   SUBSCRIBE_SUCCESS(HttpStatus.OK, "USER2003", "구독 신청 성공"),
   UNSUBSCRIBE_SUCCESS(HttpStatus.OK, "USER2004", "구독 해지 성공"),
-  GET_REPORT_LIST_SUCCESS(HttpStatus.OK, "USER2005","과거 레포트 리스트 조회 성공")
-
+  GET_REPORT_LIST_SUCCESS(HttpStatus.OK, "USER2005","과거 레포트 리스트 조회 성공"),
+  GET_REPORT_SUCCESS(HttpStatus.OK, "USER2006","단일 리포트 조회 성공")
   ;
 
   private final HttpStatus httpStatus;


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#13 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
/api/reports/{reportId} → 특정 레포트 단건 상세 조회 API 구현 완료

### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

1. 정상적으로 레포트 단건 조회가 완료되었을떄
<img width="1098" height="456" alt="스크린샷 2025-08-07 오후 5 18 05" src="https://github.com/user-attachments/assets/f1ccdba5-3f47-422d-8bb2-74a5cd3bbb43" />

2. 존재하지 않는 reportId를 입력하였을떄
<img width="302" height="102" alt="스크린샷 2025-08-07 오후 5 18 13" src="https://github.com/user-attachments/assets/24668fe3-6855-42cb-8aca-047a7aa43158" />

3. 접근 권한이 없는 reportId(다른 사람의 reportId)에 접근하였을때도 예외 처리를 추가하였습니다.

