### PR TITLE
Feat : 크레딧 관련 기능 구현 - 스케줄러, 크레딧 플랜 조회, 크레딧 차감 로직 AOP 적용

### DIFF
--- a/src/main/java/com/perfact/be/domain/alt/controller/AlternativeArticleController.java
+++ b/src/main/java/com/perfact/be/domain/alt/controller/AlternativeArticleController.java
@@ -2,7 +2,10 @@ package com.perfact.be.domain.alt.controller;
 
 import com.perfact.be.domain.alt.dto.AlternativeArticleResponseDto;
 import com.perfact.be.domain.alt.service.AlternativeArticleService;
+import com.perfact.be.domain.user.entity.User;
+import com.perfact.be.global.aop.CreditCheck;
 import com.perfact.be.global.apiPayload.ApiResponse;
+import com.perfact.be.global.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,9 +22,11 @@ public class AlternativeArticleController {
 
   private final AlternativeArticleService alternativeArticleService;
 
+  @CreditCheck(cost=1)
   @Operation(summary = "대안 기사 분석", description = "리포트의 기사 내용을 기반으로 반대 관점의 기사를 찾아 비교 분석을 수행합니다.")
   @GetMapping("/{reportId}/alternative")
   public ApiResponse<AlternativeArticleResponseDto> getAlternativeArticle(
+      @CurrentUser @Parameter(hidden = true) User loginUser,
       @Parameter(description = "리포트 ID", required = true, example = "1") @PathVariable Long reportId) {
 
     log.info("대안 기사 분석 요청 - reportId: {}", reportId);

--- a/src/main/java/com/perfact/be/domain/credit/entity/CreditLog.java
+++ b/src/main/java/com/perfact/be/domain/credit/entity/CreditLog.java
@@ -1,0 +1,47 @@
+package com.perfact.be.domain.credit.entity;
+
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.user.entity.User;
+import com.perfact.be.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreditLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(nullable = false)
+  private Long amount;
+
+  private Long balance;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length = 50, nullable = false)
+  private CreditLogType type;
+
+  private String description;
+
+}

--- a/src/main/java/com/perfact/be/domain/credit/entity/SubscriptionPlans.java
+++ b/src/main/java/com/perfact/be/domain/credit/entity/SubscriptionPlans.java
@@ -1,0 +1,36 @@
+package com.perfact.be.domain.credit.entity;
+
+import com.perfact.be.domain.credit.entity.enums.PlanType;
+import com.perfact.be.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionPlans extends BaseEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, unique = true)
+  private PlanType name;
+
+  private Long dailyCredit;
+
+  private Long price;
+
+}

--- a/src/main/java/com/perfact/be/domain/credit/entity/enums/CreditLogType.java
+++ b/src/main/java/com/perfact/be/domain/credit/entity/enums/CreditLogType.java
@@ -1,0 +1,20 @@
+package com.perfact.be.domain.credit.entity.enums;
+
+public enum CreditLogType {
+  DAILY_RESET("자정 크레딧 초기화"),
+  REPORT_CREATE("레포트 생성시 차감"),
+  ADMIN_ADJUST("관리자 수동 조정"),
+
+  ;
+
+  private final String description;
+
+  CreditLogType(String description) {
+    this.description = description;
+  }
+
+  public String getDescription(){
+    return description;
+  }
+
+}

--- a/src/main/java/com/perfact/be/domain/credit/entity/enums/PlanType.java
+++ b/src/main/java/com/perfact/be/domain/credit/entity/enums/PlanType.java
@@ -1,0 +1,5 @@
+package com.perfact.be.domain.credit.entity.enums;
+
+public enum PlanType {
+  FREE, STANDARD, PREMIUM
+}

--- a/src/main/java/com/perfact/be/domain/credit/exception/CreditHandler.java
+++ b/src/main/java/com/perfact/be/domain/credit/exception/CreditHandler.java
@@ -1,0 +1,10 @@
+package com.perfact.be.domain.credit.exception;
+
+import com.perfact.be.global.apiPayload.code.BaseErrorCode;
+import com.perfact.be.global.exception.GeneralException;
+
+public class CreditHandler extends GeneralException {
+  public CreditHandler(BaseErrorCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/perfact/be/domain/credit/exception/status/CreditErrorStatus.java
+++ b/src/main/java/com/perfact/be/domain/credit/exception/status/CreditErrorStatus.java
@@ -1,4 +1,4 @@
-package com.perfact.be.domain.user.exception.status;
+package com.perfact.be.domain.credit.exception.status;
 
 import com.perfact.be.global.apiPayload.code.BaseErrorCode;
 import com.perfact.be.global.apiPayload.code.ErrorReasonDto;
@@ -8,15 +8,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum UserErrorStatus implements BaseErrorCode {
-  USER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_4001", "유저 생성에 실패했습니다"),
-  USER_INFO_REQUIRED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_4002", "유저 파라미터가 필요합니다."),
-  USER_LOOKUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"USER_4003", "유저 조회 중 오류가 발생했습니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4004", "유저를 찾을 수 없습니다"),
-  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_4005", "해당 사용자의 구독정보를 찾을 수 없습니다." )
+public enum CreditErrorStatus implements BaseErrorCode {
+  CREDIT_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "CREDIT4001", "크레딧이 부족합니다."),
+
 
   ;
-
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
+++ b/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
@@ -1,0 +1,11 @@
+package com.perfact.be.domain.credit.repository;
+
+import com.perfact.be.domain.credit.entity.CreditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CreditLogRepository extends JpaRepository<CreditLog, Long> {
+
+
+}

--- a/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
+++ b/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
@@ -1,11 +1,35 @@
 package com.perfact.be.domain.credit.repository;
 
 import com.perfact.be.domain.credit.entity.CreditLog;
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CreditLogRepository extends JpaRepository<CreditLog, Long> {
+
+  @Query("SELECT COALESCE(SUM(c.amount), 0) FROM CreditLog c " +
+      "WHERE c.user = :user " +
+      "AND c.type = :type " +
+      "AND DATE(c.createdAt) = CURRENT_DATE")
+  Long sumTodayUsedCreditByUserAndType(
+      @Param("user") User user,
+      @Param("type") CreditLogType type
+  );
+
+  @Query("SELECT COALESCE(SUM(c.amount), 0) FROM CreditLog c " +
+      "WHERE c.user = :user " +
+      "AND c.type = :type " +
+      "AND FUNCTION('DATE_FORMAT', c.createdAt, '%Y-%m') = :yearMonth")
+  Long sumMonthlyUsedCreditByUserAndType(
+      @Param("user") User user,
+      @Param("type") CreditLogType type,
+      @Param("yearMonth") String yearMonth
+  );
+
 
 
 }

--- a/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
+++ b/src/main/java/com/perfact/be/domain/credit/repository/CreditLogRepository.java
@@ -3,6 +3,7 @@ package com.perfact.be.domain.credit.repository;
 import com.perfact.be.domain.credit.entity.CreditLog;
 import com.perfact.be.domain.credit.entity.enums.CreditLogType;
 import com.perfact.be.domain.user.entity.User;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,23 +12,16 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CreditLogRepository extends JpaRepository<CreditLog, Long> {
 
-  @Query("SELECT COALESCE(SUM(c.amount), 0) FROM CreditLog c " +
-      "WHERE c.user = :user " +
-      "AND c.type = :type " +
-      "AND DATE(c.createdAt) = CURRENT_DATE")
-  Long sumTodayUsedCreditByUserAndType(
-      @Param("user") User user,
-      @Param("type") CreditLogType type
-  );
 
   @Query("SELECT COALESCE(SUM(c.amount), 0) FROM CreditLog c " +
       "WHERE c.user = :user " +
       "AND c.type = :type " +
-      "AND FUNCTION('DATE_FORMAT', c.createdAt, '%Y-%m') = :yearMonth")
-  Long sumMonthlyUsedCreditByUserAndType(
+      "AND c.createdAt BETWEEN :start AND :end")
+  Long sumUsedCreditByUserAndTypeAndCreatedAtBetween(
       @Param("user") User user,
       @Param("type") CreditLogType type,
-      @Param("yearMonth") String yearMonth
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end
   );
 
 

--- a/src/main/java/com/perfact/be/domain/credit/repository/SubscriptionPlansRepository.java
+++ b/src/main/java/com/perfact/be/domain/credit/repository/SubscriptionPlansRepository.java
@@ -1,0 +1,11 @@
+package com.perfact.be.domain.credit.repository;
+
+import com.perfact.be.domain.credit.entity.SubscriptionPlans;
+import com.perfact.be.domain.credit.entity.enums.PlanType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionPlansRepository extends JpaRepository<SubscriptionPlans, Long> {
+  Optional<SubscriptionPlans> findByName(PlanType name);
+
+}

--- a/src/main/java/com/perfact/be/domain/credit/service/CreditLogService.java
+++ b/src/main/java/com/perfact/be/domain/credit/service/CreditLogService.java
@@ -1,0 +1,9 @@
+package com.perfact.be.domain.credit.service;
+
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.user.entity.User;
+
+public interface CreditLogService {
+
+  void createLog(User user, long amount, long balance, CreditLogType type, String description);
+}

--- a/src/main/java/com/perfact/be/domain/credit/service/CreditLogServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/credit/service/CreditLogServiceImpl.java
@@ -1,0 +1,26 @@
+package com.perfact.be.domain.credit.service;
+
+import com.perfact.be.domain.credit.entity.CreditLog;
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.credit.repository.CreditLogRepository;
+import com.perfact.be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CreditLogServiceImpl implements CreditLogService{
+  private final CreditLogRepository creditLogRepository;
+
+  @Override
+  public void createLog(User user, long amount, long balance, CreditLogType type, String description) {
+    CreditLog log = CreditLog.builder()
+        .user(user)
+        .amount(amount)
+        .balance(balance)
+        .type(type)
+        .description(description)
+        .build();
+    creditLogRepository.save(log);
+  }
+}

--- a/src/main/java/com/perfact/be/domain/report/controller/ReportController.java
+++ b/src/main/java/com/perfact/be/domain/report/controller/ReportController.java
@@ -9,6 +9,7 @@ import com.perfact.be.domain.report.repository.ReportBadgeRepository;
 import com.perfact.be.domain.report.repository.TrueScoreRepository;
 import com.perfact.be.domain.report.service.ReportService;
 import com.perfact.be.domain.user.entity.User;
+import com.perfact.be.global.aop.CreditCheck;
 import com.perfact.be.global.apiPayload.ApiResponse;
 import com.perfact.be.global.resolver.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,6 +34,7 @@ public class ReportController {
 
   @Operation(summary = "뉴스 기사 AI 분석 및 리포트 생성", description = "뉴스 URL을 입력받아 Clova API를 통해 AI 분석을 수행하고 리포트를 생성하여 저장합니다.")
   @PostMapping("")
+  @CreditCheck(cost=1)
   public ApiResponse<ReportResponseDto> analyzeNewsAndCreateReport(
       @Parameter(description = "분석할 뉴스 URL", required = true, example = "https://news.naver.com/main/read.naver?mode=LSD&mid=shm&sid1=100&oid=001&aid=0012345678") @RequestBody AnalyzeNewsRequestDTO request,
       @CurrentUser @Parameter(hidden = true) User loginUser) {

--- a/src/main/java/com/perfact/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/perfact/be/domain/user/controller/UserController.java
@@ -61,11 +61,6 @@ public class UserController {
     return ApiResponse.of(UserSuccessStatus.GET_REPORT_SUCCESS, response);
   }
 
-
-
-
-  // TODO 해야됨
-
   @Operation(summary = "구독 상태 확인", description = "현재 사용자의 구독 상태를 확인합니다.")
   @GetMapping("/subscribe")
   public ApiResponse<Object> getSubscribeStatus(
@@ -75,6 +70,10 @@ public class UserController {
     return ApiResponse.onSuccess(UserSuccessStatus.GET_SUBSCRIBE_STATUS_SUCCESS);
   }
 
+
+
+
+  // TODO 해야됨 (후순위 기능들, 네이버페이 도입예정)
   @Operation(summary = "구독하기", description = "사용자가 구독을 신청합니다.")
   @PostMapping("/subscribe")
   public ApiResponse<Object> subscribe(

--- a/src/main/java/com/perfact/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/perfact/be/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.perfact.be.domain.user.controller;
 import com.perfact.be.domain.report.dto.ReportResponseDto;
 import com.perfact.be.domain.report.dto.ReportResponseDto.ReportListDto;
 import com.perfact.be.domain.report.service.ReportService;
+import com.perfact.be.domain.user.dto.UserResponseDto.SubscribeStatusResponse;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.domain.user.exception.status.UserSuccessStatus;
 import com.perfact.be.domain.user.service.UserService;
@@ -63,11 +64,12 @@ public class UserController {
 
   @Operation(summary = "구독 상태 확인", description = "현재 사용자의 구독 상태를 확인합니다.")
   @GetMapping("/subscribe")
-  public ApiResponse<Object> getSubscribeStatus(
+  public ApiResponse<SubscribeStatusResponse> getSubscribeStatus(
       @Parameter(hidden = true) @CurrentUser User loginUser
   ) {
     //TODO : 구독상태 확인 서비스 로직 구현 예정
-    return ApiResponse.onSuccess(UserSuccessStatus.GET_SUBSCRIBE_STATUS_SUCCESS);
+    SubscribeStatusResponse response = userService.getSubscribeStatus(loginUser);
+    return ApiResponse.of(UserSuccessStatus.GET_SUBSCRIBE_STATUS_SUCCESS,response);
   }
 
 

--- a/src/main/java/com/perfact/be/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/perfact/be/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,35 @@
+package com.perfact.be.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class UserResponseDto {
+
+  @Getter
+  @AllArgsConstructor
+  @Schema(description = "구독 상태 응답 DTO")
+  public static class SubscribeStatusResponse {
+
+    @Schema(description = "플랜 이름", example = "FREE")
+    private String planName;
+
+    @Schema(description = "구독 상태 설명", example = "무료 플랜 사용 중")
+    private String subscribeStatus;
+
+    @Schema(description = "다음 결제일", example = "무료 플랜 사용 중")
+    private String nextBillingDate;
+
+    @Schema(description = "일일 크레딧 제공량", example = "3")
+    private Long dailyCredit;
+
+    @Schema(description = "오늘 사용한 크레딧 수", example = "2")
+    private Long todayUsage;
+
+    @Schema(description = "이번 달 사용한 크레딧 수", example = "15")
+    private Long thisMonthUsage;
+  }
+
+
+}
+

--- a/src/main/java/com/perfact/be/domain/user/entity/User.java
+++ b/src/main/java/com/perfact/be/domain/user/entity/User.java
@@ -1,9 +1,13 @@
 package com.perfact.be.domain.user.entity;
 
+import com.perfact.be.domain.credit.entity.CreditLog;
+import com.perfact.be.domain.credit.entity.SubscriptionPlans;
 import com.perfact.be.domain.user.entity.enums.Role;
 import com.perfact.be.domain.user.entity.enums.SocialType;
 import com.perfact.be.domain.user.entity.enums.UserStatus;
 import com.perfact.be.global.common.BaseEntity;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.*;
 import jakarta.persistence.*;
 
@@ -31,18 +35,35 @@ public class User extends BaseEntity {
   @Column(length = 20)
   private Role role;
   @Enumerated(EnumType.STRING)
+
+  @Builder.Default
   @Column(length = 20, nullable = false)
   private UserStatus status = UserStatus.ACTIVE;
 
 
 
+  @Builder.Default
   @Column(name = "is_subscribe", columnDefinition = "boolean default false")
   private Boolean isSubscribe = false;
 
+  @Builder.Default
   @Column(columnDefinition = "boolean default false")
   private Boolean isNotificationAgreed = false;
 
+  @Builder.Default
   @Column(columnDefinition = "bigint default 3")
   private Long credit = 3L;
 
+  @Builder.Default
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<CreditLog> creditLogs = new ArrayList<>();
+
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "plan_id")
+  private SubscriptionPlans plan;
+
+  public void setCredit(Long dailyCredit) {
+    this.credit = dailyCredit;
+  }
 }

--- a/src/main/java/com/perfact/be/domain/user/exception/status/UserErrorStatus.java
+++ b/src/main/java/com/perfact/be/domain/user/exception/status/UserErrorStatus.java
@@ -11,7 +11,10 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorStatus implements BaseErrorCode {
   USER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USER_4001", "유저 생성에 실패했습니다"),
   USER_LOOKUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"USER_4002", "유저 조회 중 오류가 발생했습니다."),
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4003", "유저를 찾을 수 없습니다");
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4003", "유저를 찾을 수 없습니다"),
+  PLAN_NOT_FOUND(HttpStatus.NOT_FOUND,"USER_4004", "해당 사용자의 구독정보를 찾을 수 없습니다." )
+
+  ;
 
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/perfact/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/perfact/be/domain/user/repository/UserRepository.java
@@ -2,7 +2,12 @@ package com.perfact.be.domain.user.repository;
 
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.domain.user.entity.enums.SocialType;
+import com.perfact.be.domain.user.entity.enums.UserStatus;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,4 +17,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 
 
+  @EntityGraph(attributePaths = "plan")
+  @Query("SELECT u FROM User u WHERE u.status = :status")
+  List<User> findByStatusWithPlan(@Param("status")UserStatus status);
 }

--- a/src/main/java/com/perfact/be/domain/user/service/UserService.java
+++ b/src/main/java/com/perfact/be/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.perfact.be.domain.user.service;
 
 import com.perfact.be.domain.auth.dto.NaverUserProfile;
+import com.perfact.be.domain.user.dto.UserResponseDto.SubscribeStatusResponse;
 import com.perfact.be.domain.user.entity.User;
 
 public interface UserService {
@@ -8,4 +9,6 @@ public interface UserService {
   User findOrCreateUser(NaverUserProfile profile);
 
   Object findById(Long userId);
+
+  SubscribeStatusResponse getSubscribeStatus(User loginUser);
 }

--- a/src/main/java/com/perfact/be/domain/user/service/UserService.java
+++ b/src/main/java/com/perfact/be/domain/user/service/UserService.java
@@ -11,4 +11,6 @@ public interface UserService {
   Object findById(Long userId);
 
   SubscribeStatusResponse getSubscribeStatus(User loginUser);
+
+  void decreaseCredit(User user, int cost);
 }

--- a/src/main/java/com/perfact/be/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,9 @@
 package com.perfact.be.domain.user.service;
 
 import com.perfact.be.domain.auth.dto.NaverUserProfile;
+import com.perfact.be.domain.credit.entity.SubscriptionPlans;
+import com.perfact.be.domain.credit.entity.enums.PlanType;
+import com.perfact.be.domain.credit.repository.SubscriptionPlansRepository;
 import com.perfact.be.domain.user.entity.User;
 import com.perfact.be.domain.user.entity.enums.Role;
 import com.perfact.be.domain.user.entity.enums.SocialType;
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
+  private final SubscriptionPlansRepository subscriptionPlansRepository;
 
   @Override
   @Transactional
@@ -37,6 +41,8 @@ public class UserServiceImpl implements UserService {
   }
 
   private User registerNewUser(NaverUserProfile profile) {
+    SubscriptionPlans defaultPlan = subscriptionPlansRepository.findByName(PlanType.FREE)
+        .orElseThrow(() -> new UserHandler(UserErrorStatus.PLAN_NOT_FOUND));
     try {
       User newUser = User.builder()
           .email(profile.getEmail())
@@ -45,6 +51,9 @@ public class UserServiceImpl implements UserService {
           .socialType(SocialType.NAVER)
           .role(Role.ROLE_USER)
           .status(UserStatus.ACTIVE)
+          .plan(defaultPlan)
+          .isSubscribe(false)
+          .isNotificationAgreed(false)
           .build();
 
       return userRepository.save(newUser);

--- a/src/main/java/com/perfact/be/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/perfact/be/domain/user/service/UserServiceImpl.java
@@ -4,6 +4,8 @@ import com.perfact.be.domain.auth.dto.NaverUserProfile;
 import com.perfact.be.domain.credit.entity.SubscriptionPlans;
 import com.perfact.be.domain.credit.entity.enums.CreditLogType;
 import com.perfact.be.domain.credit.entity.enums.PlanType;
+import com.perfact.be.domain.credit.exception.CreditHandler;
+import com.perfact.be.domain.credit.exception.status.CreditErrorStatus;
 import com.perfact.be.domain.credit.repository.CreditLogRepository;
 import com.perfact.be.domain.credit.repository.SubscriptionPlansRepository;
 import com.perfact.be.domain.user.dto.UserResponseDto.SubscribeStatusResponse;
@@ -86,6 +88,16 @@ public class UserServiceImpl implements UserService {
     );
   }
 
+  @Override
+  @Transactional
+  public void decreaseCredit(User user, int amount) {
+    long newCredit = user.getCredit() - amount;
+    if (newCredit < 0) {
+      throw new CreditHandler(CreditErrorStatus.CREDIT_NOT_ENOUGH);
+    }
+    user.setCredit(newCredit);
+    userRepository.save(user);
+  }
 
 
   private User registerNewUser(NaverUserProfile profile) {

--- a/src/main/java/com/perfact/be/global/aop/CreditAspect.java
+++ b/src/main/java/com/perfact/be/global/aop/CreditAspect.java
@@ -1,0 +1,56 @@
+package com.perfact.be.global.aop;
+
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.credit.exception.CreditHandler;
+import com.perfact.be.domain.credit.exception.status.CreditErrorStatus;
+import com.perfact.be.domain.credit.service.CreditLogService;
+import com.perfact.be.domain.user.entity.User;
+import com.perfact.be.domain.user.exception.UserHandler;
+import com.perfact.be.domain.user.exception.status.UserErrorStatus;
+import com.perfact.be.domain.user.service.UserService;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CreditAspect {
+
+  private final UserService userService;
+  private final CreditLogService creditLogService;
+
+  @Pointcut("@annotation(creditCheck)")
+  public void creditCheckPointcut(CreditCheck creditCheck) {}
+
+  @Around("creditCheckPointcut(creditCheck)")
+  public Object around(ProceedingJoinPoint joinPoint, CreditCheck creditCheck) throws Throwable {
+    User user = extractUser(joinPoint.getArgs());
+    int cost = creditCheck.cost();
+
+    if (user.getCredit() < cost) {
+      throw new CreditHandler(CreditErrorStatus.CREDIT_NOT_ENOUGH);
+    }
+
+    Object result = joinPoint.proceed();
+
+    userService.decreaseCredit(user, cost);
+    creditLogService.createLog(user, -cost, user.getCredit(), CreditLogType.REPORT_CREATE, CreditLogType.REPORT_CREATE.getDescription());
+
+    return result;
+  }
+
+  private User extractUser(Object[] args) {
+    return Arrays.stream(args)
+        .filter(arg -> arg instanceof User)
+        .map(arg -> (User) arg)
+        .findFirst()
+        .orElseThrow(() -> new UserHandler(UserErrorStatus.USER_LOOKUP_FAILED));
+  }
+}
+
+

--- a/src/main/java/com/perfact/be/global/aop/CreditCheck.java
+++ b/src/main/java/com/perfact/be/global/aop/CreditCheck.java
@@ -1,0 +1,13 @@
+package com.perfact.be.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CreditCheck {
+  int cost() default 1;
+
+}

--- a/src/main/java/com/perfact/be/global/scheduler/DailyCreditResetScheduler.java
+++ b/src/main/java/com/perfact/be/global/scheduler/DailyCreditResetScheduler.java
@@ -1,0 +1,58 @@
+package com.perfact.be.global.scheduler;
+
+import com.perfact.be.domain.credit.entity.CreditLog;
+import com.perfact.be.domain.credit.entity.SubscriptionPlans;
+import com.perfact.be.domain.credit.entity.enums.CreditLogType;
+import com.perfact.be.domain.credit.repository.CreditLogRepository;
+import com.perfact.be.domain.user.entity.User;
+import com.perfact.be.domain.user.entity.enums.UserStatus;
+import com.perfact.be.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyCreditResetScheduler {
+
+  private final UserRepository userRepository;
+  private final CreditLogRepository creditLogRepository;
+
+  @Scheduled(cron = "0 0 0 * * *")
+//  @Scheduled(cron = "*/30 * * * * *")
+  @Transactional
+  public void resetsCredits() {
+    log.info("[크레딧 스케줄러] : 자정 크레딧 초기화 로직 수행");
+
+    List<User> users = userRepository.findByStatusWithPlan(UserStatus.ACTIVE);
+    List<CreditLog> logs = new ArrayList<>();
+
+    for (User user : users) {
+      SubscriptionPlans plans = user.getPlan();
+      Long dailyCredit = plans.getDailyCredit();
+
+      if(dailyCredit == null || dailyCredit == -1){
+        continue;
+      }
+
+      Long before = user.getCredit();
+      user.setCredit(dailyCredit);
+
+      logs.add(CreditLog.builder()
+              .user(user)
+              .amount(dailyCredit-before)
+              .balance(dailyCredit)
+              .type(CreditLogType.DAILY_RESET)
+              .description(CreditLogType.DAILY_RESET.getDescription())
+          .build());
+
+    }
+    creditLogRepository.saveAll(logs);
+    log.info("[크레딧 스케줄러] : 자정 크레딧 초기화 로직 수행 완료. 총 {}명", logs.size());
+  }
+}


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#21 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->

1. SubscriptionPlans, CreditLog 엔티티 및 테이블 생성
2. 매일 자정 유저 크레딧을 플랜 기준으로 초기화하는 스케줄러 구현
3. 플랜 조회 및 구독 상태 확인 API 구현 (일/월 사용량 계산 로직 추가)
4. 리포트 생성 시 크레딧 검증 및 차감 로직 AOP 적용
@CreditCheck 어노테이션 생성, AOP로 메서드 실행 전후 처리 (잔여 크레딧 검증 및 사용 로그 기록)


### PR Point 및 참고사항, 스크린샷
아직 결제 기능이 구현되지 않아 다음 결제일은 임시 문자열로 대응 중입니다
AOP 처리를 통해 컨트롤러/서비스 로직을 간결하게 유지했습니다
크레딧 잔액이 부족한 경우 예외를 발생시키도록 설정되어 있습니다
<img width="303" height="110" alt="스크린샷 2025-08-09 오전 3 05 51" src="https://github.com/user-attachments/assets/23774eed-9fdb-44e2-a4a5-a0a8cf9e590e" />

만약 크레딧 차감 로직이 필요한 경우, 컨트롤러 단에
<img width="617" height="156" alt="스크린샷 2025-08-09 오전 3 14 48" src="https://github.com/user-attachments/assets/931a12f4-b2d2-4bbb-8da4-f92a8b1aa5cc" />

이런식으로 CheckCredit 커스텀 어노테이션을 달아주세요.
cost는 해당 기능을 실행할때, 필요한 크레딧의 개수를 의미합니다.
