### PR TITLE
Feat : 게스트 로그인 기능 추가 및 GUEST 플랜 추가

### DIFF
--- a/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/perfact/be/domain/auth/controller/AuthController.java
@@ -49,6 +49,18 @@ public class AuthController {
   }
 
   @Operation(
+      summary = "게스트 로그인",
+      description = "UUID 기반 게스트 계정을 생성하고 엑세스/리프레시 토큰을 발급합니다."
+  )
+  @PostMapping(value = "/guest-login", produces = "application/json")
+  public ApiResponse<AuthResponseDto.LoginResponse> guestLogin(
+  ) {
+    AuthResponseDto.LoginResponse response = authService.guestLogin();
+    return ApiResponse.of(AuthSuccessStatus.GUEST_LOGIN_SUCCESS, response);
+  }
+
+
+  @Operation(
       summary = "엑세스 토큰 재발급",
       description = "리프레시 토큰을 이용해 엑세스 토큰을 재발급합니다."
   )

--- a/src/main/java/com/perfact/be/domain/auth/exception/status/AuthSuccessStatus.java
+++ b/src/main/java/com/perfact/be/domain/auth/exception/status/AuthSuccessStatus.java
@@ -13,7 +13,10 @@ public enum AuthSuccessStatus implements BaseCode {
   SOCIAL_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2001", "소셜 로그인이 완료되었습니다."),
   DEV_TOKEN_ISSUED(HttpStatus.OK, "AUTH2002", "개발용 액세스 토큰 발급이 완료되었습니다."),
   LOGOUT_SUCCESS(HttpStatus.OK, "AUTH2003", "로그아웃이 완료되었습니다."),
-  AT_REFRESH_SUCCESS(HttpStatus.OK, "AUTH2004", "엑세스 토큰 재생성이 완료되었습니다.");
+  AT_REFRESH_SUCCESS(HttpStatus.OK, "AUTH2004", "엑세스 토큰 재생성이 완료되었습니다."),
+  GUEST_LOGIN_SUCCESS(HttpStatus.OK, "AUTH2005", "게스트 로그인이 완료되었습니다."),
+
+  ;
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/perfact/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/perfact/be/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.perfact.be.domain.auth.service;
 
 import com.perfact.be.domain.auth.dto.AuthResponseDto;
+import com.perfact.be.domain.auth.dto.AuthResponseDto.LoginResponse;
 import com.perfact.be.domain.auth.dto.AuthResponseDto.TokenResponse;
 import com.perfact.be.domain.user.entity.User;
 import jakarta.validation.constraints.NotNull;
@@ -12,4 +13,6 @@ public interface AuthService {
   TokenResponse refreshAccessToken(User loginUser, String refreshToken);
 
   void logout(User loginUser, String refreshToken);
+
+  AuthResponseDto.LoginResponse guestLogin();
 }

--- a/src/main/java/com/perfact/be/domain/credit/entity/enums/PlanType.java
+++ b/src/main/java/com/perfact/be/domain/credit/entity/enums/PlanType.java
@@ -1,5 +1,5 @@
 package com.perfact.be.domain.credit.entity.enums;
 
 public enum PlanType {
-  FREE, STANDARD, PREMIUM
+  FREE, STANDARD, PREMIUM, GUEST
 }

--- a/src/main/java/com/perfact/be/domain/user/entity/User.java
+++ b/src/main/java/com/perfact/be/domain/user/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
   private String socialId;
   @Enumerated(EnumType.STRING)
   private SocialType socialType;
-  @Column(name = "nickname", length = 10)
+  @Column(name = "nickname", length = 20)
   private String nickname;
   @Column(name = "email", length = 255)
   private String email;
@@ -35,7 +35,6 @@ public class User extends BaseEntity {
   @Column(length = 20)
   private Role role;
   @Enumerated(EnumType.STRING)
-
   @Builder.Default
   @Column(length = 20, nullable = false)
   private UserStatus status = UserStatus.ACTIVE;

--- a/src/main/java/com/perfact/be/domain/user/entity/enums/Role.java
+++ b/src/main/java/com/perfact/be/domain/user/entity/enums/Role.java
@@ -1,5 +1,5 @@
 package com.perfact.be.domain.user.entity.enums;
 
 public enum Role {
-  ROLE_USER, ROLE_ADMIN
+  ROLE_USER, ROLE_ADMIN, ROLE_GUEST;
 }

--- a/src/main/java/com/perfact/be/domain/user/entity/enums/SocialType.java
+++ b/src/main/java/com/perfact/be/domain/user/entity/enums/SocialType.java
@@ -1,5 +1,5 @@
 package com.perfact.be.domain.user.entity.enums;
 
 public enum SocialType {
-  NAVER, KAKAO
+  NAVER, KAKAO, GUEST
 }

--- a/src/main/java/com/perfact/be/domain/user/service/UserService.java
+++ b/src/main/java/com/perfact/be/domain/user/service/UserService.java
@@ -16,4 +16,6 @@ public interface UserService {
   void decreaseCredit(User user, int cost);
 
   NicknameResponse getNickname(User loginUser);
+
+  User createGuestUser(String deviceUuid);
 }

--- a/src/main/java/com/perfact/be/global/config/SecurityConfig.java
+++ b/src/main/java/com/perfact/be/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/swagger-ui.html",
                 "/api/auth/social-login/**",
+                "/api/auth/guest-login/**",
                 "/dev/auth/**"
             ).permitAll()
             .anyRequest().authenticated()


### PR DESCRIPTION
### 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
#31 

### 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
게스트 로그인 API를 구현하였습니다.

- POST /api/auth/guest-login 구현
- deviceUuid 기반 게스트 유저 생성
- RefreshToken Redis 저장 및 기존 refresh/logout 로직 재사용 가능

UserService.createGuestUser 서비스 로직을 추가하였습니다.
- PlanType.GUEST 부여
- 초기 크레딧 10개 설정

구독 상태 조회(getSubscribeStatus) 기능을 수정하였습니다.

- GUEST 플랜 문구/상태 분기 추가


### PR Point 및 참고사항, 스크린샷
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
RDS PlanType 테이블에 GUEST 플랜 데이터를 추가해야 합니다..! (현재 추가안한상태라 해당 API 호출 시 NON_PLAN 에러 발생)
현재 구조상 게스트 유저 데이터가 계속 누적되는 상황입니다.
이 문제를 해결하기 위해 게스트 유저 데이터를 주기적으로 정리하는 배치 작업도 진행할 예정입니다.

게스트 로그인 API 호출시
<img width="1168" height="233" alt="스크린샷 2025-08-17 오전 4 27 56" src="https://github.com/user-attachments/assets/deb715f7-d448-4329-bf24-8b8dd43c014d" />
닉네임 조회 호출시
<img width="1170" height="149" alt="스크린샷 2025-08-17 오전 4 27 36" src="https://github.com/user-attachments/assets/9542afe6-ba10-4219-a1dc-9a80056004e4" />
게스트 로그인 후 구독상태 조회 api 호출시
<img width="1169" height="227" alt="스크린샷 2025-08-17 오전 4 27 18" src="https://github.com/user-attachments/assets/693bf417-a4b8-4911-aeca-166a0cd95c37" />


